### PR TITLE
Add upserts to bigquery connector for flink 2.1

### DIFF
--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -67,6 +67,8 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
     // CDC configuration
     final boolean cdcEnabled;
     final String cdcSequenceField;
+    final List<String> cdcPrimaryKeyColumns;
+    final String cdcMaxStaleness;
     final CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
 
     BigQueryBaseSink(BigQuerySinkConfig<IN> sinkConfig) {
@@ -94,6 +96,8 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
         maxParallelism = getMaxParallelism();
         cdcEnabled = sinkConfig.isCdcEnabled();
         cdcSequenceField = sinkConfig.getCdcSequenceField();
+        cdcPrimaryKeyColumns = sinkConfig.getCdcPrimaryKeyColumns();
+        cdcMaxStaleness = sinkConfig.getCdcMaxStaleness();
         cdcChangeTypeProvider = (CdcChangeTypeProvider<IN>) sinkConfig.getCdcChangeTypeProvider();
     }
 
@@ -133,7 +137,10 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
                 partitionType,
                 partitionExpirationMillis,
                 clusteredFields,
-                region);
+                region,
+                cdcEnabled,
+                cdcPrimaryKeyColumns,
+                cdcMaxStaleness);
     }
 
     private String getRegion(String userProvidedRegion) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryBaseSink.java
@@ -26,6 +26,7 @@ import com.google.cloud.flink.bigquery.sink.client.BigQueryClientWithErrorHandli
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl;
+import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
 import com.google.cloud.flink.bigquery.sink.writer.CreateTableOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,6 +64,10 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
     final boolean fatalizeSerializer;
     final int maxParallelism;
     String traceId;
+    // CDC configuration
+    final boolean cdcEnabled;
+    final String cdcSequenceField;
+    final CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
 
     BigQueryBaseSink(BigQuerySinkConfig<IN> sinkConfig) {
         validateSinkConfig(sinkConfig);
@@ -87,6 +92,9 @@ abstract class BigQueryBaseSink<IN> implements Sink<IN> {
         region = getRegion(sinkConfig.getRegion());
         fatalizeSerializer = sinkConfig.fatalizeSerializer();
         maxParallelism = getMaxParallelism();
+        cdcEnabled = sinkConfig.isCdcEnabled();
+        cdcSequenceField = sinkConfig.getCdcSequenceField();
+        cdcChangeTypeProvider = (CdcChangeTypeProvider<IN>) sinkConfig.getCdcChangeTypeProvider();
     }
 
     private void validateSinkConfig(BigQuerySinkConfig<IN> sinkConfig) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQueryDefaultSink.java
@@ -52,6 +52,9 @@ class BigQueryDefaultSink<IN> extends BigQueryBaseSink<IN> {
                 fatalizeSerializer,
                 maxParallelism,
                 traceId,
+                cdcEnabled,
+                cdcSequenceField,
+                cdcChangeTypeProvider,
                 context);
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -18,6 +18,7 @@ package com.google.cloud.flink.bigquery.sink;
 
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.util.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,8 +91,21 @@ public class BigQuerySink {
                             + "Records will be written without _change_sequence_number, so ordering "
                             + "between multiple changes to the same primary key may be nondeterministic.");
         }
+        if (sinkConfig.enableTableCreation()) {
+            if (sinkConfig.getCdcPrimaryKeyColumns() == null
+                    || sinkConfig.getCdcPrimaryKeyColumns().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "CDC table auto-creation requires write.cdc-primary-key-columns to be set.");
+            }
+            if (StringUtils.isNullOrWhitespaceOnly(sinkConfig.getCdcMaxStaleness())) {
+                throw new IllegalArgumentException(
+                        "CDC table auto-creation requires write.cdc-max-staleness to be set.");
+            }
+        }
         LOG.info(
                 "CDC mode enabled. Ensure the destination BigQuery table has a PRIMARY KEY "
-                        + "constraint and max_staleness option configured for CDC to work properly.");
+                        + "constraint and max_staleness option configured for CDC to work properly. "
+                        + "If table auto-creation is enabled, configure them with "
+                        + "write.cdc-primary-key-columns and write.cdc-max-staleness.");
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -85,8 +85,10 @@ public class BigQuerySink {
         }
         if (sinkConfig.getCdcSequenceField() == null
                 || sinkConfig.getCdcSequenceField().isEmpty()) {
-            throw new IllegalArgumentException(
-                    "CDC mode requires write.cdc-sequence-field to be set for ordering changes.");
+            LOG.warn(
+                    "CDC mode enabled without write.cdc-sequence-field. "
+                            + "Records will be written without _change_sequence_number, so ordering "
+                            + "between multiple changes to the same primary key may be nondeterministic.");
         }
         LOG.info(
                 "CDC mode enabled. Ensure the destination BigQuery table has a PRIMARY KEY "

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -63,7 +63,6 @@ public class BigQuerySink {
      *
      * <p>CDC mode has the following requirements: - Must use AT_LEAST_ONCE delivery guarantee (CDC
      * uses the default stream) - The destination BigQuery table must have a PRIMARY KEY constraint
-     * - The destination BigQuery table must have max_staleness option configured
      *
      * <p>Note: Table-level requirements (PRIMARY KEY, max_staleness) are not validated here as they
      * require BigQuery API calls. They will be validated at runtime.
@@ -98,14 +97,19 @@ public class BigQuerySink {
                         "CDC table auto-creation requires write.cdc-primary-key-columns to be set.");
             }
             if (StringUtils.isNullOrWhitespaceOnly(sinkConfig.getCdcMaxStaleness())) {
-                throw new IllegalArgumentException(
-                        "CDC table auto-creation requires write.cdc-max-staleness to be set.");
+                LOG.warn(
+                        "CDC table auto-creation enabled without write.cdc-max-staleness. "
+                                + "The table will still be created, but max_staleness will remain unset. "
+                                + "If needed, run ALTER TABLE ... SET OPTIONS (max_staleness = INTERVAL ...)"
+                                + " after creation.");
             }
         }
         LOG.info(
                 "CDC mode enabled. Ensure the destination BigQuery table has a PRIMARY KEY "
-                        + "constraint and max_staleness option configured for CDC to work properly. "
-                        + "If table auto-creation is enabled, configure them with "
-                        + "write.cdc-primary-key-columns and write.cdc-max-staleness.");
+                        + "constraint configured for CDC to work properly. "
+                        + "If table auto-creation is enabled, configure primary keys with "
+                        + "write.cdc-primary-key-columns. max_staleness is optional, but if omitted "
+                        + "or not persisted by BigQuery during create, it may need to be set later "
+                        + "with ALTER TABLE ... SET OPTIONS.");
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -79,7 +79,9 @@ public class BigQuerySink {
                     sinkConfig.getDeliveryGuarantee());
             throw new IllegalArgumentException(
                     "CDC mode requires AT_LEAST_ONCE delivery guarantee. "
-                            + "BigQuery CDC uses the default stream which provides at-least-once semantics.");
+                            + "BigQuery CDC uses the default stream which provides at-least-once semantics. "
+                            + "Found: "
+                            + sinkConfig.getDeliveryGuarantee());
         }
         if (sinkConfig.getCdcSequenceField() == null
                 || sinkConfig.getCdcSequenceField().isEmpty()) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -81,6 +81,11 @@ public class BigQuerySink {
                     "CDC mode requires AT_LEAST_ONCE delivery guarantee. "
                             + "BigQuery CDC uses the default stream which provides at-least-once semantics.");
         }
+        if (sinkConfig.getCdcSequenceField() == null
+                || sinkConfig.getCdcSequenceField().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "CDC mode requires write.cdc-sequence-field to be set for ordering changes.");
+        }
         LOG.info(
                 "CDC mode enabled. Ensure the destination BigQuery table has a PRIMARY KEY "
                         + "constraint and max_staleness option configured for CDC to work properly.");

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySink.java
@@ -41,6 +41,9 @@ public class BigQuerySink {
     private static final Logger LOG = LoggerFactory.getLogger(BigQuerySink.class);
 
     public static <IN> Sink<IN> get(BigQuerySinkConfig<IN> sinkConfig) {
+        if (sinkConfig.isCdcEnabled()) {
+            validateCdcConfiguration(sinkConfig);
+        }
         if (sinkConfig.getDeliveryGuarantee() == DeliveryGuarantee.AT_LEAST_ONCE) {
             return new BigQueryDefaultSink<>(sinkConfig);
         }
@@ -52,5 +55,34 @@ public class BigQuerySink {
                 sinkConfig.getDeliveryGuarantee());
         throw new UnsupportedOperationException(
                 String.format("%s is not supported", sinkConfig.getDeliveryGuarantee()));
+    }
+
+    /**
+     * Validates CDC configuration requirements.
+     *
+     * <p>CDC mode has the following requirements: - Must use AT_LEAST_ONCE delivery guarantee (CDC
+     * uses the default stream) - The destination BigQuery table must have a PRIMARY KEY constraint
+     * - The destination BigQuery table must have max_staleness option configured
+     *
+     * <p>Note: Table-level requirements (PRIMARY KEY, max_staleness) are not validated here as they
+     * require BigQuery API calls. They will be validated at runtime.
+     *
+     * @param sinkConfig The sink configuration to validate.
+     * @throws IllegalArgumentException if CDC configuration is invalid.
+     */
+    private static void validateCdcConfiguration(BigQuerySinkConfig<?> sinkConfig) {
+        if (sinkConfig.getDeliveryGuarantee() != DeliveryGuarantee.AT_LEAST_ONCE) {
+            LOG.error(
+                    "CDC mode requires AT_LEAST_ONCE delivery guarantee. "
+                            + "BigQuery CDC uses the default stream which provides at-least-once semantics. "
+                            + "Found: {}",
+                    sinkConfig.getDeliveryGuarantee());
+            throw new IllegalArgumentException(
+                    "CDC mode requires AT_LEAST_ONCE delivery guarantee. "
+                            + "BigQuery CDC uses the default stream which provides at-least-once semantics.");
+        }
+        LOG.info(
+                "CDC mode enabled. Ensure the destination BigQuery table has a PRIMARY KEY "
+                        + "constraint and max_staleness option configured for CDC to work properly.");
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -351,6 +351,38 @@ public class BigQuerySinkConfig<IN> {
             List<String> clusteredFields,
             String region,
             boolean fatalizeSerializer) {
+        return forTable(
+                connectOptions,
+                deliveryGuarantee,
+                logicalType,
+                enableTableCreation,
+                partitionField,
+                partitionType,
+                partitionExpirationMillis,
+                clusteredFields,
+                region,
+                fatalizeSerializer,
+                false,
+                null,
+                null);
+    }
+
+    /** Table API overload with CDC support. */
+    @Internal
+    public static BigQuerySinkConfig<RowData> forTable(
+            BigQueryConnectOptions connectOptions,
+            DeliveryGuarantee deliveryGuarantee,
+            LogicalType logicalType,
+            boolean enableTableCreation,
+            String partitionField,
+            TimePartitioning.Type partitionType,
+            Long partitionExpirationMillis,
+            List<String> clusteredFields,
+            String region,
+            boolean fatalizeSerializer,
+            boolean cdcEnabled,
+            String cdcSequenceField,
+            CdcChangeTypeProvider<RowData> cdcChangeTypeProvider) {
         return new BigQuerySinkConfig<>(
                 connectOptions,
                 deliveryGuarantee,
@@ -364,9 +396,9 @@ public class BigQuerySinkConfig<IN> {
                 clusteredFields,
                 region,
                 fatalizeSerializer,
-                false, // CDC not supported for Table API yet
-                null,
-                null);
+                cdcEnabled,
+                cdcSequenceField,
+                cdcChangeTypeProvider);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -30,6 +30,7 @@ import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryTableSchemaProvider;
+import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.RowDataToProtoSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +69,10 @@ public class BigQuerySinkConfig<IN> {
     private final List<String> clusteredFields;
     private final String region;
     private final boolean fatalizeSerializer;
+    // CDC (Change Data Capture) configuration
+    private final boolean cdcEnabled;
+    private final String cdcSequenceField;
+    private final CdcChangeTypeProvider<?> cdcChangeTypeProvider;
 
     public static <IN> Builder<IN> newBuilder() {
         return new Builder<>();
@@ -86,7 +91,10 @@ public class BigQuerySinkConfig<IN> {
                 partitionExpirationMillis,
                 clusteredFields,
                 region,
-                fatalizeSerializer);
+                fatalizeSerializer,
+                cdcEnabled,
+                cdcSequenceField,
+                cdcChangeTypeProvider);
     }
 
     @Override
@@ -112,7 +120,11 @@ public class BigQuerySinkConfig<IN> {
                 && (Objects.equals(this.getClusteredFields(), object.getClusteredFields()))
                 && (Objects.equals(this.getRegion(), object.getRegion()))
                 && (Objects.equals(this.getSchemaProvider(), object.getSchemaProvider()))
-                && (this.fatalizeSerializer() == object.fatalizeSerializer()));
+                && (this.fatalizeSerializer() == object.fatalizeSerializer())
+                && (this.isCdcEnabled() == object.isCdcEnabled())
+                && (Objects.equals(this.getCdcSequenceField(), object.getCdcSequenceField()))
+                && (Objects.equals(
+                        this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider())));
     }
 
     private BigQuerySinkConfig(
@@ -126,7 +138,10 @@ public class BigQuerySinkConfig<IN> {
             Long partitionExpirationMillis,
             List<String> clusteredFields,
             String region,
-            boolean fatalizeSerializer) {
+            boolean fatalizeSerializer,
+            boolean cdcEnabled,
+            String cdcSequenceField,
+            CdcChangeTypeProvider<?> cdcChangeTypeProvider) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
         this.schemaProvider = schemaProvider;
@@ -138,6 +153,9 @@ public class BigQuerySinkConfig<IN> {
         this.clusteredFields = clusteredFields;
         this.region = region;
         this.fatalizeSerializer = fatalizeSerializer;
+        this.cdcEnabled = cdcEnabled;
+        this.cdcSequenceField = cdcSequenceField;
+        this.cdcChangeTypeProvider = cdcChangeTypeProvider;
     }
 
     public BigQueryConnectOptions getConnectOptions() {
@@ -184,6 +202,18 @@ public class BigQuerySinkConfig<IN> {
         return fatalizeSerializer;
     }
 
+    public boolean isCdcEnabled() {
+        return cdcEnabled;
+    }
+
+    public String getCdcSequenceField() {
+        return cdcSequenceField;
+    }
+
+    public CdcChangeTypeProvider<?> getCdcChangeTypeProvider() {
+        return cdcChangeTypeProvider;
+    }
+
     /**
      * Builder for BigQuerySinkConfig.
      *
@@ -203,6 +233,10 @@ public class BigQuerySinkConfig<IN> {
         private String region;
         private boolean fatalizeSerializer;
         private StreamExecutionEnvironment env;
+        // CDC configuration
+        private boolean cdcEnabled;
+        private String cdcSequenceField;
+        private CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
 
         public Builder<IN> connectOptions(BigQueryConnectOptions connectOptions) {
             this.connectOptions = connectOptions;
@@ -265,6 +299,21 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> enableCdc(boolean cdcEnabled) {
+            this.cdcEnabled = cdcEnabled;
+            return this;
+        }
+
+        public Builder<IN> cdcSequenceField(String cdcSequenceField) {
+            this.cdcSequenceField = cdcSequenceField;
+            return this;
+        }
+
+        public Builder<IN> cdcChangeTypeProvider(CdcChangeTypeProvider<IN> cdcChangeTypeProvider) {
+            this.cdcChangeTypeProvider = cdcChangeTypeProvider;
+            return this;
+        }
+
         public BigQuerySinkConfig<IN> build() {
             if (deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE) {
                 validateStreamExecutionEnvironment(env);
@@ -280,7 +329,10 @@ public class BigQuerySinkConfig<IN> {
                     partitionExpirationMillis,
                     clusteredFields,
                     region,
-                    fatalizeSerializer);
+                    fatalizeSerializer,
+                    cdcEnabled,
+                    cdcSequenceField,
+                    cdcChangeTypeProvider);
         }
     }
 
@@ -311,7 +363,10 @@ public class BigQuerySinkConfig<IN> {
                 partitionExpirationMillis,
                 clusteredFields,
                 region,
-                fatalizeSerializer);
+                fatalizeSerializer,
+                false, // CDC not supported for Table API yet
+                null,
+                null);
     }
 
     public static void validateStreamExecutionEnvironment(StreamExecutionEnvironment env) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfig.java
@@ -72,6 +72,8 @@ public class BigQuerySinkConfig<IN> {
     // CDC (Change Data Capture) configuration
     private final boolean cdcEnabled;
     private final String cdcSequenceField;
+    private final List<String> cdcPrimaryKeyColumns;
+    private final String cdcMaxStaleness;
     private final CdcChangeTypeProvider<?> cdcChangeTypeProvider;
 
     public static <IN> Builder<IN> newBuilder() {
@@ -94,6 +96,8 @@ public class BigQuerySinkConfig<IN> {
                 fatalizeSerializer,
                 cdcEnabled,
                 cdcSequenceField,
+                cdcPrimaryKeyColumns,
+                cdcMaxStaleness,
                 cdcChangeTypeProvider);
     }
 
@@ -124,6 +128,9 @@ public class BigQuerySinkConfig<IN> {
                 && (this.isCdcEnabled() == object.isCdcEnabled())
                 && (Objects.equals(this.getCdcSequenceField(), object.getCdcSequenceField()))
                 && (Objects.equals(
+                        this.getCdcPrimaryKeyColumns(), object.getCdcPrimaryKeyColumns()))
+                && (Objects.equals(this.getCdcMaxStaleness(), object.getCdcMaxStaleness()))
+                && (Objects.equals(
                         this.getCdcChangeTypeProvider(), object.getCdcChangeTypeProvider())));
     }
 
@@ -141,6 +148,8 @@ public class BigQuerySinkConfig<IN> {
             boolean fatalizeSerializer,
             boolean cdcEnabled,
             String cdcSequenceField,
+            List<String> cdcPrimaryKeyColumns,
+            String cdcMaxStaleness,
             CdcChangeTypeProvider<?> cdcChangeTypeProvider) {
         this.connectOptions = connectOptions;
         this.deliveryGuarantee = deliveryGuarantee;
@@ -155,6 +164,8 @@ public class BigQuerySinkConfig<IN> {
         this.fatalizeSerializer = fatalizeSerializer;
         this.cdcEnabled = cdcEnabled;
         this.cdcSequenceField = cdcSequenceField;
+        this.cdcPrimaryKeyColumns = cdcPrimaryKeyColumns;
+        this.cdcMaxStaleness = cdcMaxStaleness;
         this.cdcChangeTypeProvider = cdcChangeTypeProvider;
     }
 
@@ -210,6 +221,14 @@ public class BigQuerySinkConfig<IN> {
         return cdcSequenceField;
     }
 
+    public List<String> getCdcPrimaryKeyColumns() {
+        return cdcPrimaryKeyColumns;
+    }
+
+    public String getCdcMaxStaleness() {
+        return cdcMaxStaleness;
+    }
+
     public CdcChangeTypeProvider<?> getCdcChangeTypeProvider() {
         return cdcChangeTypeProvider;
     }
@@ -236,6 +255,8 @@ public class BigQuerySinkConfig<IN> {
         // CDC configuration
         private boolean cdcEnabled;
         private String cdcSequenceField;
+        private List<String> cdcPrimaryKeyColumns;
+        private String cdcMaxStaleness;
         private CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
 
         public Builder<IN> connectOptions(BigQueryConnectOptions connectOptions) {
@@ -309,6 +330,16 @@ public class BigQuerySinkConfig<IN> {
             return this;
         }
 
+        public Builder<IN> cdcPrimaryKeyColumns(List<String> cdcPrimaryKeyColumns) {
+            this.cdcPrimaryKeyColumns = cdcPrimaryKeyColumns;
+            return this;
+        }
+
+        public Builder<IN> cdcMaxStaleness(String cdcMaxStaleness) {
+            this.cdcMaxStaleness = cdcMaxStaleness;
+            return this;
+        }
+
         public Builder<IN> cdcChangeTypeProvider(CdcChangeTypeProvider<IN> cdcChangeTypeProvider) {
             this.cdcChangeTypeProvider = cdcChangeTypeProvider;
             return this;
@@ -332,6 +363,8 @@ public class BigQuerySinkConfig<IN> {
                     fatalizeSerializer,
                     cdcEnabled,
                     cdcSequenceField,
+                    cdcPrimaryKeyColumns,
+                    cdcMaxStaleness,
                     cdcChangeTypeProvider);
         }
     }
@@ -364,6 +397,8 @@ public class BigQuerySinkConfig<IN> {
                 fatalizeSerializer,
                 false,
                 null,
+                null,
+                null,
                 null);
     }
 
@@ -382,6 +417,8 @@ public class BigQuerySinkConfig<IN> {
             boolean fatalizeSerializer,
             boolean cdcEnabled,
             String cdcSequenceField,
+            List<String> cdcPrimaryKeyColumns,
+            String cdcMaxStaleness,
             CdcChangeTypeProvider<RowData> cdcChangeTypeProvider) {
         return new BigQuerySinkConfig<>(
                 connectOptions,
@@ -398,6 +435,8 @@ public class BigQuerySinkConfig<IN> {
                 fatalizeSerializer,
                 cdcEnabled,
                 cdcSequenceField,
+                cdcPrimaryKeyColumns,
+                cdcMaxStaleness,
                 cdcChangeTypeProvider);
     }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/client/BigQueryClientWithErrorHandling.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/client/BigQueryClientWithErrorHandling.java
@@ -16,16 +16,27 @@
 
 package com.google.cloud.flink.bigquery.sink.client;
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.bigquery.Bigquery;
+import com.google.api.services.bigquery.model.Clustering;
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
+import com.google.cloud.flink.bigquery.common.utils.SchemaTransform;
 import com.google.cloud.flink.bigquery.services.BigQueryServices;
 import com.google.cloud.flink.bigquery.services.BigQueryServicesFactory;
+import com.google.cloud.flink.bigquery.services.BigQueryUtils;
+import com.google.cloud.flink.bigquery.sink.writer.CreateTableOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
 
 import static com.google.cloud.flink.bigquery.services.BigQueryServicesImpl.ALREADY_EXISTS_ERROR_CODE;
 
@@ -104,20 +115,39 @@ public class BigQueryClientWithErrorHandling {
     }
 
     public static void createTable(
-            BigQueryConnectOptions connectOptions, TableDefinition tableDefinition) {
+            BigQueryConnectOptions connectOptions,
+            TableDefinition tableDefinition,
+            CreateTableOptions createTableOptions) {
         try {
-            BigQueryServices.QueryDataClient queryDataClient =
-                    BigQueryServicesFactory.instance(connectOptions).queryClient();
-            queryDataClient.createTable(
-                    connectOptions.getProjectId(),
-                    connectOptions.getDataset(),
-                    connectOptions.getTable(),
-                    tableDefinition);
+            if (createTableOptions.isCdcEnabled()) {
+                Bigquery bigquery =
+                        BigQueryUtils.newBigqueryBuilder(connectOptions.getCredentialsOptions())
+                                .build();
+                bigquery.tables()
+                        .insert(
+                                connectOptions.getProjectId(),
+                                connectOptions.getDataset(),
+                                toCdcTable(connectOptions, tableDefinition, createTableOptions))
+                        .setPrettyPrint(false)
+                        .execute();
+            } else {
+                BigQueryServices.QueryDataClient queryDataClient =
+                        BigQueryServicesFactory.instance(connectOptions).queryClient();
+                queryDataClient.createTable(
+                        connectOptions.getProjectId(),
+                        connectOptions.getDataset(),
+                        connectOptions.getTable(),
+                        tableDefinition);
+            }
             LOG.info(
                     "Created BigQuery table {}.{}.{}",
                     connectOptions.getProjectId(),
                     connectOptions.getDataset(),
                     connectOptions.getTable());
+        } catch (GoogleJsonResponseException e) {
+            throw new BigQueryException(e.getStatusCode(), e.getMessage(), e);
+        } catch (IOException e) {
+            throw new BigQueryException(0, e.getMessage(), e);
         } catch (BigQueryException e) {
             if (e.getCode() == ALREADY_EXISTS_ERROR_CODE) {
                 LOG.warn(
@@ -135,6 +165,49 @@ public class BigQueryClientWithErrorHandling {
                             connectOptions.getTable()),
                     e);
         }
+    }
+
+    static Table toCdcTable(
+            BigQueryConnectOptions connectOptions,
+            TableDefinition tableDefinition,
+            CreateTableOptions createTableOptions) {
+        Table table =
+                new Table()
+                        .setTableReference(
+                                new com.google.api.services.bigquery.model.TableReference()
+                                        .setProjectId(connectOptions.getProjectId())
+                                        .setDatasetId(connectOptions.getDataset())
+                                        .setTableId(connectOptions.getTable()))
+                        .setSchema(
+                                SchemaTransform.bigQuerySchemaToTableSchema(
+                                        tableDefinition.getSchema()))
+                        .setTableConstraints(
+                                new TableConstraints()
+                                        .setPrimaryKey(
+                                                new TableConstraints.PrimaryKey()
+                                                        .setColumns(
+                                                                new ArrayList<>(
+                                                                        createTableOptions
+                                                                                .getCdcPrimaryKeyColumns()))))
+                        .setMaxStaleness(createTableOptions.getCdcMaxStaleness());
+        if (createTableOptions.getPartitionType() != null) {
+            com.google.api.services.bigquery.model.TimePartitioning timePartitioning =
+                    new com.google.api.services.bigquery.model.TimePartitioning()
+                            .setType(createTableOptions.getPartitionType().name());
+            if (createTableOptions.getPartitionField() != null) {
+                timePartitioning.setField(createTableOptions.getPartitionField());
+            }
+            if (createTableOptions.getPartitionExpirationMillis() > 0) {
+                timePartitioning.setExpirationMs(createTableOptions.getPartitionExpirationMillis());
+            }
+            table.setTimePartitioning(timePartitioning);
+        }
+        if (createTableOptions.getClusteredFields() != null
+                && !createTableOptions.getClusteredFields().isEmpty()) {
+            table.setClustering(
+                    new Clustering().setFields(createTableOptions.getClusteredFields()));
+        }
+        return table;
     }
 
     public static Dataset getDataset(BigQueryConnectOptions connectOptions) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
@@ -64,6 +64,8 @@ import java.util.concurrent.TimeUnit;
 public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord> {
 
     private Descriptor descriptor;
+    // CDC-augmented descriptor (includes _change_type and _change_sequence_number fields)
+    private Descriptor cdcDescriptor;
 
     /**
      * Prepares the serializer before its serialize method can be called. It allows contextual
@@ -83,6 +85,23 @@ public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord
         this.descriptor = derivedDescriptor;
     }
 
+    /**
+     * Initializes the serializer for CDC mode with an augmented schema.
+     *
+     * @param bigQuerySchemaProvider The CDC-augmented schema provider.
+     */
+    @Override
+    public void initForCdc(BigQuerySchemaProvider bigQuerySchemaProvider) {
+        Preconditions.checkNotNull(
+                bigQuerySchemaProvider,
+                "BigQuerySchemaProvider not found while initializing AvroToProtoSerializer for CDC");
+        Descriptor derivedDescriptor = bigQuerySchemaProvider.getDescriptor();
+        Preconditions.checkNotNull(
+                derivedDescriptor,
+                "Destination BigQuery table's CDC Proto Schema could not be found.");
+        this.cdcDescriptor = derivedDescriptor;
+    }
+
     @Override
     public Schema getAvroSchema(GenericRecord record) {
         return record.getSchema();
@@ -99,6 +118,130 @@ public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord
                             record, e.getMessage()),
                     e);
         }
+    }
+
+    @Override
+    public ByteString serializeWithCdc(
+            GenericRecord record, String changeType, String changeSequenceNumber)
+            throws BigQuerySerializationException {
+        try {
+            return getDynamicMessageFromGenericRecordWithCdc(
+                            record, this.cdcDescriptor, changeType, changeSequenceNumber)
+                    .toByteString();
+        } catch (Exception e) {
+            throw new BigQuerySerializationException(
+                    String.format(
+                            "Error while serialising Avro GenericRecord with CDC: %s\nError: %s",
+                            record, e.getMessage()),
+                    e);
+        }
+    }
+
+    @Override
+    public String extractSequenceNumber(GenericRecord record, String sequenceField) {
+        if (sequenceField == null || sequenceField.isEmpty()) {
+            return null;
+        }
+
+        Schema recordSchema = record.getSchema();
+        if (recordSchema.getField(sequenceField) == null) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Sequence field '%s' does not exist in the record schema. "
+                                    + "Available fields: %s",
+                            sequenceField,
+                            recordSchema.getFields().stream()
+                                    .map(Schema.Field::name)
+                                    .collect(java.util.stream.Collectors.toList())));
+        }
+
+        Object value = record.get(sequenceField);
+        if (value == null) {
+            return null;
+        }
+
+        Long longValue = convertToLong(value);
+        if (longValue == null) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot convert sequence field '%s' value '%s' of type '%s' to Long. "
+                                    + "Supported types: Long, Integer, java.time.Instant, "
+                                    + "org.joda.time.Instant, or numeric String.",
+                            sequenceField, value, value.getClass().getName()));
+        }
+
+        return String.format("%016X", longValue);
+    }
+
+    private Long convertToLong(Object value) {
+        if (value instanceof Long) {
+            return (Long) value;
+        } else if (value instanceof Integer) {
+            return ((Integer) value).longValue();
+        } else if (value instanceof java.time.Instant) {
+            return ((java.time.Instant) value).toEpochMilli();
+        } else if (value instanceof org.joda.time.Instant) {
+            return ((org.joda.time.Instant) value).getMillis();
+        } else if (value instanceof org.joda.time.ReadableInstant) {
+            return ((org.joda.time.ReadableInstant) value).getMillis();
+        }
+
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Converts a Generic Avro Record to Dynamic Message with CDC pseudocolumns included.
+     *
+     * @param element The GenericRecord to convert.
+     * @param descriptor The CDC-augmented descriptor.
+     * @param changeType The CDC change type.
+     * @param changeSequenceNumber The sequence number.
+     * @return DynamicMessage with CDC fields.
+     */
+    public static DynamicMessage getDynamicMessageFromGenericRecordWithCdc(
+            GenericRecord element,
+            Descriptor descriptor,
+            String changeType,
+            String changeSequenceNumber) {
+        Schema recordSchema = element.getSchema();
+        DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
+
+        for (Schema.Field field : recordSchema.getFields()) {
+            FieldDescriptor fieldDescriptor =
+                    descriptor.findFieldByName(field.name().toLowerCase());
+            if (fieldDescriptor == null) {
+                continue;
+            }
+            @Nullable Object value = element.get(field.name());
+            if (value == null) {
+                if (fieldDescriptor.isRequired()) {
+                    throw new IllegalArgumentException(
+                            "Received null value for non-nullable field "
+                                    + fieldDescriptor.getName());
+                }
+            } else {
+                value = toProtoValue(fieldDescriptor, field.schema(), value);
+                builder.setField(fieldDescriptor, value);
+            }
+        }
+
+        FieldDescriptor changeTypeField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD);
+        FieldDescriptor sequenceField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD);
+
+        if (changeTypeField != null && changeType != null) {
+            builder.setField(changeTypeField, changeType);
+        }
+        if (sequenceField != null && changeSequenceNumber != null) {
+            builder.setField(sequenceField, changeSequenceNumber);
+        }
+
+        return builder.build();
     }
 
     /**

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializer.java
@@ -59,6 +59,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /** Serializer for converting Avro's {@link GenericRecord} to BigQuery proto. */
 public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord> {
@@ -152,7 +153,7 @@ public class AvroToProtoSerializer extends BigQueryProtoSerializer<GenericRecord
                             sequenceField,
                             recordSchema.getFields().stream()
                                     .map(Schema.Field::name)
-                                    .collect(java.util.stream.Collectors.toList())));
+                                    .collect(Collectors.toList())));
         }
 
         Object value = record.get(sequenceField);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryCdcSchemaProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryCdcSchemaProvider.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.serializer;
+
+import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import org.apache.avro.Schema;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A BigQuery schema provider that wraps an existing schema provider and augments it with CDC
+ * (Change Data Capture) pseudocolumns.
+ *
+ * <p>BigQuery CDC requires two pseudocolumns to be included in write operations:
+ *
+ * <ul>
+ *   <li>{@code _change_type}: String value of "UPSERT" or "DELETE"
+ *   <li>{@code _change_sequence_number}: Hexadecimal string for ordering changes
+ * </ul>
+ *
+ * <p>These pseudocolumns are not stored as table columns but are metadata that BigQuery uses during
+ * ingestion to perform upsert/delete operations based on the table's primary key.
+ *
+ * @see <a href="https://cloud.google.com/bigquery/docs/change-data-capture">BigQuery CDC
+ *     Documentation</a>
+ */
+public class BigQueryCdcSchemaProvider implements BigQuerySchemaProvider {
+
+    /** Name of the CDC change type pseudocolumn. */
+    public static final String CDC_CHANGE_TYPE_FIELD = "_change_type";
+
+    /** Name of the CDC sequence number pseudocolumn. */
+    public static final String CDC_SEQUENCE_NUMBER_FIELD = "_change_sequence_number";
+
+    private final BigQuerySchemaProvider delegate;
+    private final Schema augmentedAvroSchema;
+    private final DescriptorProto augmentedDescriptorProto;
+    private final Descriptor augmentedDescriptor;
+
+    /**
+     * Creates a new CDC schema provider wrapping the given schema provider.
+     *
+     * @param delegate The underlying schema provider to augment with CDC columns.
+     */
+    public BigQueryCdcSchemaProvider(BigQuerySchemaProvider delegate) {
+        this.delegate = delegate;
+
+        if (delegate.schemaUnknown()) {
+            this.augmentedAvroSchema = null;
+            this.augmentedDescriptorProto = null;
+            this.augmentedDescriptor = null;
+        } else {
+            this.augmentedAvroSchema = createAugmentedAvroSchema(delegate.getAvroSchema());
+            this.augmentedDescriptorProto =
+                    createAugmentedDescriptorProto(delegate.getDescriptorProto());
+            this.augmentedDescriptor = buildDescriptor(augmentedDescriptorProto);
+        }
+    }
+
+    @Override
+    public DescriptorProto getDescriptorProto() {
+        return augmentedDescriptorProto;
+    }
+
+    @Override
+    public Descriptor getDescriptor() {
+        return augmentedDescriptor;
+    }
+
+    @Override
+    public Schema getAvroSchema() {
+        return augmentedAvroSchema;
+    }
+
+    @Override
+    public boolean schemaUnknown() {
+        return delegate.schemaUnknown();
+    }
+
+    /**
+     * Creates an augmented Avro schema with CDC pseudocolumns added.
+     *
+     * @param baseSchema The original Avro schema.
+     * @return A new schema with CDC fields appended.
+     */
+    private static Schema createAugmentedAvroSchema(Schema baseSchema) {
+        List<Schema.Field> augmentedFields = new ArrayList<>();
+
+        // Copy all existing fields
+        for (Schema.Field field : baseSchema.getFields()) {
+            augmentedFields.add(
+                    new Schema.Field(
+                            field.name(),
+                            field.schema(),
+                            field.doc(),
+                            field.defaultVal(),
+                            field.order()));
+        }
+
+        // Add CDC pseudocolumns as nullable strings
+        Schema nullableString =
+                Schema.createUnion(
+                        Schema.create(Schema.Type.NULL), Schema.create(Schema.Type.STRING));
+
+        augmentedFields.add(
+                new Schema.Field(
+                        CDC_CHANGE_TYPE_FIELD,
+                        nullableString,
+                        "CDC change type: UPSERT or DELETE",
+                        Schema.Field.NULL_DEFAULT_VALUE));
+
+        augmentedFields.add(
+                new Schema.Field(
+                        CDC_SEQUENCE_NUMBER_FIELD,
+                        nullableString,
+                        "CDC sequence number for ordering (hexadecimal string)",
+                        Schema.Field.NULL_DEFAULT_VALUE));
+
+        return Schema.createRecord(
+                baseSchema.getName(),
+                baseSchema.getDoc(),
+                baseSchema.getNamespace(),
+                baseSchema.isError(),
+                augmentedFields);
+    }
+
+    /**
+     * Creates an augmented DescriptorProto with CDC pseudocolumns added.
+     *
+     * @param baseDescriptorProto The original descriptor proto.
+     * @return A new descriptor proto with CDC fields appended.
+     */
+    private static DescriptorProto createAugmentedDescriptorProto(
+            DescriptorProto baseDescriptorProto) {
+        DescriptorProto.Builder builder = baseDescriptorProto.toBuilder();
+
+        // Find the next available field number
+        int maxFieldNumber = 0;
+        for (FieldDescriptorProto field : baseDescriptorProto.getFieldList()) {
+            maxFieldNumber = Math.max(maxFieldNumber, field.getNumber());
+        }
+
+        // Add _change_type field
+        builder.addField(
+                FieldDescriptorProto.newBuilder()
+                        .setName(CDC_CHANGE_TYPE_FIELD)
+                        .setNumber(maxFieldNumber + 1)
+                        .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                        .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .build());
+
+        // Add _change_sequence_number field
+        builder.addField(
+                FieldDescriptorProto.newBuilder()
+                        .setName(CDC_SEQUENCE_NUMBER_FIELD)
+                        .setNumber(maxFieldNumber + 2)
+                        .setType(FieldDescriptorProto.Type.TYPE_STRING)
+                        .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+                        .build());
+
+        return builder.build();
+    }
+
+    /**
+     * Builds a Descriptor from a DescriptorProto.
+     *
+     * @param descriptorProto The descriptor proto to convert.
+     * @return The built Descriptor.
+     * @throws BigQueryConnectorException if descriptor validation fails.
+     */
+    private static Descriptor buildDescriptor(DescriptorProto descriptorProto) {
+        try {
+            FileDescriptorProto fileDescriptorProto =
+                    FileDescriptorProto.newBuilder().addMessageType(descriptorProto).build();
+            FileDescriptor fileDescriptor =
+                    FileDescriptor.buildFrom(fileDescriptorProto, new FileDescriptor[0]);
+            List<Descriptor> descriptorTypeList = fileDescriptor.getMessageTypes();
+            if (descriptorTypeList.size() == 1) {
+                return descriptorTypeList.get(0);
+            } else {
+                throw new IllegalArgumentException(
+                        String.format("Expected one element but was %s", descriptorTypeList));
+            }
+        } catch (DescriptorValidationException | IllegalArgumentException e) {
+            throw new BigQueryConnectorException(
+                    "Could not build Descriptor for CDC-augmented schema", e);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(delegate, augmentedAvroSchema);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        BigQueryCdcSchemaProvider other = (BigQueryCdcSchemaProvider) obj;
+        return Objects.equals(delegate, other.delegate)
+                && Objects.equals(augmentedAvroSchema, other.augmentedAvroSchema);
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
@@ -74,8 +74,9 @@ public abstract class BigQueryProtoSerializer<IN> implements Serializable {
     /**
      * Convert Flink record to proto ByteString with CDC metadata included.
      *
-     * <p>The default implementation calls {@link #serialize(Object)}. Subclasses that support CDC
-     * should override this method to include the CDC pseudocolumns in the serialized output.
+     * <p>The default implementation throws {@link UnsupportedOperationException}. Subclasses that
+     * support CDC must override this method to include the CDC pseudocolumns in the serialized
+     * output.
      *
      * @param record Record to serialize.
      * @param changeType The CDC change type ("UPSERT" or "DELETE").
@@ -85,9 +86,11 @@ public abstract class BigQueryProtoSerializer<IN> implements Serializable {
      */
     public ByteString serializeWithCdc(IN record, String changeType, String changeSequenceNumber)
             throws BigQuerySerializationException {
-        // Default implementation ignores CDC fields for backward compatibility.
-        // Subclasses should override to include CDC pseudocolumns.
-        return serialize(record);
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Serializer %s does not support CDC serialization. "
+                                + "Override serializeWithCdc() to handle change type '%s'.",
+                        getClass().getName(), changeType));
     }
 
     /**
@@ -96,15 +99,19 @@ public abstract class BigQueryProtoSerializer<IN> implements Serializable {
      * <p>The sequence number is used by BigQuery to determine the order of changes for records with
      * the same primary key. Higher sequence numbers take precedence.
      *
-     * <p>The default implementation returns null. Subclasses should override this method to extract
-     * a meaningful sequence number from the record.
+     * <p>The default implementation throws {@link UnsupportedOperationException}. Subclasses that
+     * support CDC must override this method to extract a meaningful sequence number from the
+     * record.
      *
      * @param record Record to extract sequence number from.
-     * @param sequenceField The name of the field containing the sequence value, or null.
-     * @return Hexadecimal string representation of the sequence number, or null to omit.
+     * @param sequenceField The name of the field containing the sequence value.
+     * @return Hexadecimal string representation of the sequence number.
      */
     public String extractSequenceNumber(IN record, String sequenceField) {
-        // Intentionally return null so non-CDC serializers can omit sequence numbers.
-        return null;
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Serializer %s does not support CDC sequence extraction. "
+                                + "Override extractSequenceNumber() to use sequence field '%s'.",
+                        getClass().getName(), sequenceField));
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
@@ -104,6 +104,7 @@ public abstract class BigQueryProtoSerializer<IN> implements Serializable {
      * @return Hexadecimal string representation of the sequence number, or null to omit.
      */
     public String extractSequenceNumber(IN record, String sequenceField) {
+        // Intentionally return null so non-CDC serializers can omit sequence numbers.
         return null;
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializer.java
@@ -56,4 +56,54 @@ public abstract class BigQueryProtoSerializer<IN> implements Serializable {
      * @return Schema.
      */
     public abstract Schema getAvroSchema(IN record);
+
+    /**
+     * Initializes the serializer for CDC mode with an augmented schema that includes CDC
+     * pseudocolumns. This will be called once for every serializer instance before its first
+     * serialize call when CDC is enabled.
+     *
+     * <p>The default implementation calls {@link #init(BigQuerySchemaProvider)}. Subclasses should
+     * override this method to store the CDC-aware descriptor separately.
+     *
+     * @param schemaProvider BigQuery table's schema information augmented with CDC columns.
+     */
+    public void initForCdc(BigQuerySchemaProvider schemaProvider) {
+        init(schemaProvider);
+    }
+
+    /**
+     * Convert Flink record to proto ByteString with CDC metadata included.
+     *
+     * <p>The default implementation calls {@link #serialize(Object)}. Subclasses that support CDC
+     * should override this method to include the CDC pseudocolumns in the serialized output.
+     *
+     * @param record Record to serialize.
+     * @param changeType The CDC change type ("UPSERT" or "DELETE").
+     * @param changeSequenceNumber The sequence number for ordering (hexadecimal string).
+     * @return ByteString with CDC metadata included.
+     * @throws BigQuerySerializationException If serialization failed.
+     */
+    public ByteString serializeWithCdc(IN record, String changeType, String changeSequenceNumber)
+            throws BigQuerySerializationException {
+        // Default implementation ignores CDC fields for backward compatibility.
+        // Subclasses should override to include CDC pseudocolumns.
+        return serialize(record);
+    }
+
+    /**
+     * Extracts a sequence number from the record for CDC ordering.
+     *
+     * <p>The sequence number is used by BigQuery to determine the order of changes for records with
+     * the same primary key. Higher sequence numbers take precedence.
+     *
+     * <p>The default implementation returns null. Subclasses should override this method to extract
+     * a meaningful sequence number from the record.
+     *
+     * @param record Record to extract sequence number from.
+     * @param sequenceField The name of the field containing the sequence value, or null.
+     * @return Hexadecimal string representation of the sequence number, or null to omit.
+     */
+    public String extractSequenceNumber(IN record, String sequenceField) {
+        return null;
+    }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/CdcChangeTypeProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/CdcChangeTypeProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.serializer;
+
+import java.io.Serializable;
+
+/**
+ * Functional interface for determining the CDC change type for a record.
+ *
+ * <p>This interface allows users to provide custom logic for determining whether a record
+ * represents an UPSERT or DELETE operation in BigQuery's CDC mode.
+ *
+ * <p>BigQuery CDC supports two change types:
+ *
+ * <ul>
+ *   <li>{@code "UPSERT"} - Insert or update a row based on the primary key
+ *   <li>{@code "DELETE"} - Delete a row with the matching primary key
+ * </ul>
+ *
+ * @param <IN> Type of records being written to BigQuery.
+ */
+@FunctionalInterface
+public interface CdcChangeTypeProvider<IN> extends Serializable {
+
+    /**
+     * Determines the CDC change type for the given record.
+     *
+     * @param record The record to determine the change type for.
+     * @return The change type string, either "UPSERT" or "DELETE".
+     */
+    String getChangeType(IN record);
+
+    /**
+     * Returns a provider that always returns "UPSERT" for all records.
+     *
+     * @param <IN> Type of records.
+     * @return A CdcChangeTypeProvider that always returns "UPSERT".
+     */
+    static <IN> CdcChangeTypeProvider<IN> upsertOnly() {
+        return record -> "UPSERT";
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataCdcChangeTypeProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataCdcChangeTypeProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.serializer;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+/**
+ * {@link CdcChangeTypeProvider} for Flink {@link RowData} that maps {@link RowKind} to CDC change
+ * type.
+ *
+ * <p>RowKind mapping: INSERT, UPDATE_AFTER -> UPSERT; UPDATE_BEFORE, DELETE -> DELETE.
+ */
+public final class RowDataCdcChangeTypeProvider implements CdcChangeTypeProvider<RowData> {
+
+    private static final RowDataCdcChangeTypeProvider INSTANCE = new RowDataCdcChangeTypeProvider();
+
+    private RowDataCdcChangeTypeProvider() {}
+
+    @Override
+    public String getChangeType(RowData record) {
+        if (record == null) {
+            return "UPSERT";
+        }
+        RowKind kind = record.getRowKind();
+        return (kind == RowKind.UPDATE_BEFORE || kind == RowKind.DELETE) ? "DELETE" : "UPSERT";
+    }
+
+    public static RowDataCdcChangeTypeProvider getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
@@ -170,10 +170,10 @@ public class RowDataToProtoSerializer extends BigQueryProtoSerializer<RowData> {
                 return (long) record.getInt(fieldIndex);
             case TIMESTAMP_WITHOUT_TIME_ZONE:
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                int precision = fieldType.getChildren().isEmpty() ? 3 : 6; // Default 3 for millis
+                int precision;
                 if (fieldType instanceof TimestampType) {
                     precision = ((TimestampType) fieldType).getPrecision();
-                } else if (fieldType instanceof LocalZonedTimestampType) {
+                } else {
                     precision = ((LocalZonedTimestampType) fieldType).getPrecision();
                 }
                 TimestampData ts = record.getTimestamp(fieldIndex, precision);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/serializer/RowDataToProtoSerializer.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 
@@ -56,6 +57,7 @@ public class RowDataToProtoSerializer extends BigQueryProtoSerializer<RowData> {
 
     private final LogicalType type;
     private Descriptor descriptor;
+    private Descriptor cdcDescriptor;
 
     public RowDataToProtoSerializer(LogicalType type) {
         this.type = type;
@@ -72,11 +74,23 @@ public class RowDataToProtoSerializer extends BigQueryProtoSerializer<RowData> {
     public void init(BigQuerySchemaProvider bigQuerySchemaProvider) {
         Preconditions.checkNotNull(
                 bigQuerySchemaProvider,
-                "BigQuerySchemaProvider not found while initializing AvroToProtoSerializer");
+                "BigQuerySchemaProvider not found while initializing RowDataToProtoSerializer");
         Descriptor derivedDescriptor = bigQuerySchemaProvider.getDescriptor();
         Preconditions.checkNotNull(
                 derivedDescriptor, "Destination BigQuery table's Proto Schema could not be found.");
         this.descriptor = derivedDescriptor;
+    }
+
+    @Override
+    public void initForCdc(BigQuerySchemaProvider bigQuerySchemaProvider) {
+        Preconditions.checkNotNull(
+                bigQuerySchemaProvider,
+                "BigQuerySchemaProvider not found while initializing RowDataToProtoSerializer for CDC");
+        Descriptor derivedDescriptor = bigQuerySchemaProvider.getDescriptor();
+        Preconditions.checkNotNull(
+                derivedDescriptor,
+                "Destination BigQuery table's CDC Proto Schema could not be found.");
+        this.cdcDescriptor = derivedDescriptor;
     }
 
     @Override
@@ -96,6 +110,113 @@ public class RowDataToProtoSerializer extends BigQueryProtoSerializer<RowData> {
                             record, e.getMessage()),
                     e);
         }
+    }
+
+    @Override
+    public ByteString serializeWithCdc(
+            RowData record, String changeType, String changeSequenceNumber)
+            throws BigQuerySerializationException {
+        try {
+            return getDynamicMessageFromRowDataWithCdc(
+                            record, this.cdcDescriptor, this.type, changeType, changeSequenceNumber)
+                    .toByteString();
+        } catch (Exception e) {
+            throw new BigQuerySerializationException(
+                    String.format(
+                            "Error while serialising Row Data record with CDC: %s\nError: %s",
+                            record, e.getMessage()),
+                    e);
+        }
+    }
+
+    @Override
+    public String extractSequenceNumber(RowData record, String sequenceField) {
+        if (sequenceField == null || sequenceField.isEmpty()) {
+            return null;
+        }
+        if (!(type instanceof RowType)) {
+            throw new IllegalArgumentException(
+                    "CDC sequence field extraction requires RowType, got: " + type.getClass());
+        }
+        RowType rowType = (RowType) type;
+        int fieldIndex = rowType.getFieldNames().indexOf(sequenceField);
+        if (fieldIndex < 0) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Sequence field '%s' does not exist. Available: %s",
+                            sequenceField, rowType.getFieldNames()));
+        }
+        if (record.isNullAt(fieldIndex)) {
+            return null;
+        }
+        LogicalType fieldType = rowType.getTypeAt(fieldIndex);
+        Long longValue = extractLongFromRowData(record, fieldIndex, fieldType);
+        if (longValue == null) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Cannot convert sequence field '%s' to Long. Supported: BIGINT, INT, TIMESTAMP.",
+                            sequenceField));
+        }
+        return String.format("%016X", longValue);
+    }
+
+    private Long extractLongFromRowData(RowData record, int fieldIndex, LogicalType fieldType) {
+        switch (fieldType.getTypeRoot()) {
+            case BIGINT:
+                return record.getLong(fieldIndex);
+            case INTEGER:
+            case TINYINT:
+            case SMALLINT:
+                return (long) record.getInt(fieldIndex);
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                int precision = fieldType.getChildren().isEmpty() ? 3 : 6; // Default 3 for millis
+                if (fieldType instanceof TimestampType) {
+                    precision = ((TimestampType) fieldType).getPrecision();
+                } else if (fieldType instanceof LocalZonedTimestampType) {
+                    precision = ((LocalZonedTimestampType) fieldType).getPrecision();
+                }
+                TimestampData ts = record.getTimestamp(fieldIndex, precision);
+                return ts.getMillisecond();
+            default:
+                return null;
+        }
+    }
+
+    private DynamicMessage getDynamicMessageFromRowDataWithCdc(
+            RowData element,
+            Descriptor descriptor,
+            LogicalType type,
+            String changeType,
+            String changeSequenceNumber) {
+        DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
+        int fieldNumber = 0;
+        for (LogicalType fieldType : type.getChildren()) {
+            FieldDescriptor fieldDescriptor =
+                    Preconditions.checkNotNull(descriptor.findFieldByNumber(fieldNumber + 1));
+            if (element.isNullAt(fieldNumber)) {
+                if (fieldDescriptor.isRequired()) {
+                    throw new IllegalArgumentException(
+                            "Received null value for non-nullable field "
+                                    + fieldDescriptor.getName());
+                }
+            } else {
+                Object value = toProtoValue(fieldType, fieldNumber, element, fieldDescriptor);
+                builder.setField(fieldDescriptor, value);
+            }
+            fieldNumber += 1;
+        }
+        FieldDescriptor changeTypeField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD);
+        FieldDescriptor sequenceField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD);
+        if (changeTypeField != null) {
+            builder.setField(changeTypeField, changeType);
+        }
+        if (sequenceField != null && changeSequenceNumber != null) {
+            builder.setField(sequenceField, changeSequenceNumber);
+        }
+        return builder.build();
     }
 
     public Object toProtoValue(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -265,7 +265,8 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
                 connectOptions.getProjectId(),
                 connectOptions.getDataset(),
                 connectOptions.getTable());
-        BigQueryClientWithErrorHandling.createTable(connectOptions, getTableDefinition());
+        BigQueryClientWithErrorHandling.createTable(
+                connectOptions, getTableDefinition(), createTableOptions);
     }
 
     /** Creates a StreamWriter for appending to BigQuery table. */

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -39,9 +39,11 @@ import com.google.cloud.flink.bigquery.services.BigQueryServices;
 import com.google.cloud.flink.bigquery.services.BigQueryServicesFactory;
 import com.google.cloud.flink.bigquery.sink.client.BigQueryClientWithErrorHandling;
 import com.google.cloud.flink.bigquery.sink.exceptions.BigQuerySerializationException;
+import com.google.cloud.flink.bigquery.sink.serializer.BigQueryCdcSchemaProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProviderImpl;
+import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
 import com.google.cloud.flink.bigquery.sink.throttle.BigQueryWriterThrottler;
 import com.google.cloud.flink.bigquery.sink.throttle.Throttler;
 import com.google.protobuf.ByteString;
@@ -101,6 +103,10 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     final boolean fatalizeSerializer;
     final String traceId;
     final Queue<AppendInfo> appendResponseFuturesQueue;
+    // CDC configuration
+    final boolean cdcEnabled;
+    final String cdcSequenceField;
+    final CdcChangeTypeProvider<IN> cdcChangeTypeProvider;
     // Initialization of writeClient has been deferred to first append call. BigQuery's best
     // practices suggest that client connections should be opened when needed.
     BigQueryServices.StorageWriteClient writeClient;
@@ -127,7 +133,10 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
             CreateTableOptions createTableOptions,
             boolean fatalizeSerializer,
             int maxParallelism,
-            String traceId) {
+            String traceId,
+            boolean cdcEnabled,
+            String cdcSequenceField,
+            CdcChangeTypeProvider<IN> cdcChangeTypeProvider) {
         this.subtaskId = subtaskId;
         this.tablePath = tablePath;
         this.connectOptions = connectOptions;
@@ -136,6 +145,12 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
         this.createTableOptions = createTableOptions;
         this.fatalizeSerializer = fatalizeSerializer;
         this.traceId = traceId;
+        this.cdcEnabled = cdcEnabled;
+        this.cdcSequenceField = cdcSequenceField;
+        this.cdcChangeTypeProvider =
+                cdcChangeTypeProvider != null
+                        ? cdcChangeTypeProvider
+                        : CdcChangeTypeProvider.upsertOnly();
         appendRequestSizeBytes = 0L;
         appendResponseFuturesQueue = new LinkedList<>();
         protoRowsBuilder = ProtoRows.newBuilder();
@@ -197,8 +212,17 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
                 schemaProvider = new BigQuerySchemaProviderImpl(avroSchema);
             }
         }
-        protoSchema = getProtoSchema(schemaProvider);
-        serializer.init(schemaProvider);
+
+        if (cdcEnabled) {
+            BigQuerySchemaProvider cdcSchemaProvider =
+                    new BigQueryCdcSchemaProvider(schemaProvider);
+            protoSchema = getProtoSchema(cdcSchemaProvider);
+            serializer.init(schemaProvider);
+            serializer.initForCdc(cdcSchemaProvider);
+        } else {
+            protoSchema = getProtoSchema(schemaProvider);
+            serializer.init(schemaProvider);
+        }
     }
 
     /** Add serialized record to append request. */
@@ -292,12 +316,22 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
     /**
      * Serializes a record to BigQuery's proto format.
      *
+     * <p>If CDC mode is enabled, this method will include CDC pseudocolumns (_change_type and
+     * _change_sequence_number) in the serialized output.
+     *
      * @param element Record to serialize.
      * @return ByteString.
      * @throws BigQuerySerializationException If serialization to proto format failed.
      */
     ByteString getProtoRow(IN element) throws BigQuerySerializationException {
-        ByteString protoRow = serializer.serialize(element);
+        ByteString protoRow;
+        if (cdcEnabled) {
+            String changeType = cdcChangeTypeProvider.getChangeType(element);
+            String sequenceNumber = serializer.extractSequenceNumber(element, cdcSequenceField);
+            protoRow = serializer.serializeWithCdc(element, changeType, sequenceNumber);
+        } else {
+            protoRow = serializer.serialize(element);
+        }
         if (getProtoRowBytes(protoRow) > MAX_APPEND_REQUEST_BYTES) {
             logger.error(
                     "A single row of size %d bytes exceeded the allowed maximum of %d bytes for an append request",

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BaseWriter.java
@@ -213,15 +213,13 @@ abstract class BaseWriter<IN> implements SinkWriter<IN> {
             }
         }
 
+        protoSchema = getProtoSchema(schemaProvider);
+        serializer.init(schemaProvider);
         if (cdcEnabled) {
             BigQuerySchemaProvider cdcSchemaProvider =
                     new BigQueryCdcSchemaProvider(schemaProvider);
             protoSchema = getProtoSchema(cdcSchemaProvider);
-            serializer.init(schemaProvider);
             serializer.initForCdc(cdcSchemaProvider);
-        } else {
-            protoSchema = getProtoSchema(schemaProvider);
-            serializer.init(schemaProvider);
         }
     }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -153,7 +153,10 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                 createTableOptions,
                 fatalizeSerializer,
                 maxParallelism,
-                traceId);
+                traceId,
+                false, // CDC not supported with exactly-once (uses buffered streams)
+                null,
+                null);
         this.streamNameInState = StringUtils.isNullOrWhitespaceOnly(streamName) ? "" : streamName;
         this.streamName = this.streamNameInState;
         this.streamOffsetInState = streamOffset;

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriter.java
@@ -154,9 +154,9 @@ public class BigQueryBufferedWriter<IN> extends BaseWriter<IN>
                 fatalizeSerializer,
                 maxParallelism,
                 traceId,
-                false, // CDC not supported with exactly-once (uses buffered streams)
-                null,
-                null);
+                false, // cdcEnabled: buffered streams do not support CDC
+                null, // cdcSequenceField: unused because CDC is disabled
+                null); // cdcChangeTypeProvider: unused because CDC is disabled
         this.streamNameInState = StringUtils.isNullOrWhitespaceOnly(streamName) ? "" : streamName;
         this.streamName = this.streamNameInState;
         this.streamOffsetInState = streamOffset;

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriter.java
@@ -30,6 +30,7 @@ import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorExcept
 import com.google.cloud.flink.bigquery.sink.exceptions.BigQuerySerializationException;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
+import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
 import com.google.protobuf.ByteString;
 
 import java.util.concurrent.ExecutionException;
@@ -68,6 +69,9 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
             boolean fatalizeSerializer,
             int maxParallelism,
             String taceId,
+            boolean cdcEnabled,
+            String cdcSequenceField,
+            CdcChangeTypeProvider<IN> cdcChangeTypeProvider,
             WriterInitContext context) {
         super(
                 context.getTaskInfo().getIndexOfThisSubtask(),
@@ -78,7 +82,10 @@ public class BigQueryDefaultWriter<IN> extends BaseWriter<IN> {
                 createTableOptions,
                 fatalizeSerializer,
                 maxParallelism,
-                taceId);
+                taceId,
+                cdcEnabled,
+                cdcSequenceField,
+                cdcChangeTypeProvider);
         streamName = String.format("%s/streams/_default", tablePath);
         totalRecordsSeen = 0L;
         totalRecordsWritten = 0L;

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/CreateTableOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/sink/writer/CreateTableOptions.java
@@ -29,6 +29,9 @@ public class CreateTableOptions {
     private final long partitionExpirationMillis;
     private final List<String> clusteredFields;
     private final String region;
+    private final boolean cdcEnabled;
+    private final List<String> cdcPrimaryKeyColumns;
+    private final String cdcMaxStaleness;
 
     public CreateTableOptions(
             boolean enableTableCreation,
@@ -36,7 +39,10 @@ public class CreateTableOptions {
             TimePartitioning.Type partitionType,
             Long partitionExpirationMillis,
             List<String> clusteredFields,
-            String region) {
+            String region,
+            boolean cdcEnabled,
+            List<String> cdcPrimaryKeyColumns,
+            String cdcMaxStaleness) {
         this.enableTableCreation = enableTableCreation;
         this.partitionField = partitionField;
         this.partitionType = partitionType;
@@ -47,6 +53,9 @@ public class CreateTableOptions {
         }
         this.clusteredFields = clusteredFields;
         this.region = region;
+        this.cdcEnabled = cdcEnabled;
+        this.cdcPrimaryKeyColumns = cdcPrimaryKeyColumns;
+        this.cdcMaxStaleness = cdcMaxStaleness;
     }
 
     public boolean enableTableCreation() {
@@ -71,5 +80,17 @@ public class CreateTableOptions {
 
     public String getRegion() {
         return region;
+    }
+
+    public boolean isCdcEnabled() {
+        return cdcEnabled;
+    }
+
+    public List<String> getCdcPrimaryKeyColumns() {
+        return cdcPrimaryKeyColumns;
+    }
+
+    public String getCdcMaxStaleness() {
+        return cdcMaxStaleness;
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -85,6 +85,8 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.REGION);
         additionalOptions.add(BigQueryConnectorOptions.CDC_ENABLED);
         additionalOptions.add(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD);
+        additionalOptions.add(BigQueryConnectorOptions.CDC_PRIMARY_KEY_COLUMNS);
+        additionalOptions.add(BigQueryConnectorOptions.CDC_MAX_STALENESS);
 
         return additionalOptions;
     }
@@ -117,6 +119,8 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.FATALIZE_SERIALIZER);
         forwardOptions.add(BigQueryConnectorOptions.CDC_ENABLED);
         forwardOptions.add(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD);
+        forwardOptions.add(BigQueryConnectorOptions.CDC_PRIMARY_KEY_COLUMNS);
+        forwardOptions.add(BigQueryConnectorOptions.CDC_MAX_STALENESS);
 
         return forwardOptions;
     }
@@ -174,6 +178,8 @@ public class BigQueryDynamicTableFactory
                 configProvider.fatalizeSerializer(),
                 configProvider.isCdcEnabled(),
                 configProvider.getCdcSequenceField().orElse(null),
+                configProvider.getCdcPrimaryKeyColumns().orElse(null),
+                configProvider.getCdcMaxStaleness().orElse(null),
                 null);
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -83,6 +83,8 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.PARTITION_EXPIRATION_MILLIS);
         additionalOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
         additionalOptions.add(BigQueryConnectorOptions.REGION);
+        additionalOptions.add(BigQueryConnectorOptions.CDC_ENABLED);
+        additionalOptions.add(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD);
 
         return additionalOptions;
     }
@@ -113,6 +115,8 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.CLUSTERED_FIELDS);
         forwardOptions.add(BigQueryConnectorOptions.REGION);
         forwardOptions.add(BigQueryConnectorOptions.FATALIZE_SERIALIZER);
+        forwardOptions.add(BigQueryConnectorOptions.CDC_ENABLED);
+        forwardOptions.add(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD);
 
         return forwardOptions;
     }
@@ -167,6 +171,9 @@ public class BigQueryDynamicTableFactory
                 configProvider.getPartitionExpirationMillis().orElse(null),
                 configProvider.getClusteredFields().orElse(null),
                 configProvider.getRegion().orElse(null),
-                configProvider.fatalizeSerializer());
+                configProvider.fatalizeSerializer(),
+                configProvider.isCdcEnabled(),
+                configProvider.getCdcSequenceField().orElse(null),
+                null);
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -28,6 +28,8 @@ import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.sink.BigQuerySink;
 import com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig;
+import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
+import com.google.cloud.flink.bigquery.sink.serializer.RowDataCdcChangeTypeProvider;
 
 import java.util.List;
 import java.util.Objects;
@@ -53,6 +55,38 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
             List<String> clusteredFields,
             String region,
             boolean fatalizeSerializer) {
+        this(
+                connectOptions,
+                deliveryGuarantee,
+                logicalType,
+                parallelism,
+                enableTableCreation,
+                partitionField,
+                partitionType,
+                partitionExpirationMillis,
+                clusteredFields,
+                region,
+                fatalizeSerializer,
+                false,
+                null,
+                null);
+    }
+
+    public BigQueryDynamicTableSink(
+            BigQueryConnectOptions connectOptions,
+            DeliveryGuarantee deliveryGuarantee,
+            LogicalType logicalType,
+            Integer parallelism,
+            boolean enableTableCreation,
+            String partitionField,
+            TimePartitioning.Type partitionType,
+            Long partitionExpirationMillis,
+            List<String> clusteredFields,
+            String region,
+            boolean fatalizeSerializer,
+            boolean cdcEnabled,
+            String cdcSequenceField,
+            CdcChangeTypeProvider<org.apache.flink.table.data.RowData> cdcChangeTypeProvider) {
         this.logicalType = logicalType;
         this.parallelism = parallelism;
         this.sinkConfig =
@@ -66,7 +100,12 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                         partitionExpirationMillis,
                         clusteredFields,
                         region,
-                        fatalizeSerializer);
+                        fatalizeSerializer,
+                        cdcEnabled,
+                        cdcSequenceField,
+                        cdcEnabled && cdcChangeTypeProvider == null
+                                ? RowDataCdcChangeTypeProvider.getInstance()
+                                : cdcChangeTypeProvider);
     }
 
     @Override
@@ -99,7 +138,7 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
 
     @Override
     public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
-        return ChangelogMode.insertOnly();
+        return sinkConfig.isCdcEnabled() ? ChangelogMode.all() : ChangelogMode.insertOnly();
     }
 
     @Override
@@ -124,7 +163,11 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 this.sinkConfig.getPartitionExpirationMillis(),
                 this.sinkConfig.getClusteredFields(),
                 this.sinkConfig.getRegion(),
-                this.sinkConfig.fatalizeSerializer());
+                this.sinkConfig.fatalizeSerializer(),
+                this.sinkConfig.isCdcEnabled(),
+                this.sinkConfig.getCdcSequenceField(),
+                (CdcChangeTypeProvider<org.apache.flink.table.data.RowData>)
+                        this.sinkConfig.getCdcChangeTypeProvider());
     }
 
     @Override

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSink.java
@@ -69,6 +69,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 fatalizeSerializer,
                 false,
                 null,
+                null,
+                null,
                 null);
     }
 
@@ -86,6 +88,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
             boolean fatalizeSerializer,
             boolean cdcEnabled,
             String cdcSequenceField,
+            List<String> cdcPrimaryKeyColumns,
+            String cdcMaxStaleness,
             CdcChangeTypeProvider<org.apache.flink.table.data.RowData> cdcChangeTypeProvider) {
         this.logicalType = logicalType;
         this.parallelism = parallelism;
@@ -103,6 +107,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                         fatalizeSerializer,
                         cdcEnabled,
                         cdcSequenceField,
+                        cdcPrimaryKeyColumns,
+                        cdcMaxStaleness,
                         cdcEnabled && cdcChangeTypeProvider == null
                                 ? RowDataCdcChangeTypeProvider.getInstance()
                                 : cdcChangeTypeProvider);
@@ -166,6 +172,8 @@ public class BigQueryDynamicTableSink implements DynamicTableSink {
                 this.sinkConfig.fatalizeSerializer(),
                 this.sinkConfig.isCdcEnabled(),
                 this.sinkConfig.getCdcSequenceField(),
+                this.sinkConfig.getCdcPrimaryKeyColumns(),
+                this.sinkConfig.getCdcMaxStaleness(),
                 (CdcChangeTypeProvider<org.apache.flink.table.data.RowData>)
                         this.sinkConfig.getCdcChangeTypeProvider());
     }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -270,15 +270,28 @@ public class BigQueryConnectorOptions {
                                     + "auto-creates a CDC destination table.");
 
     /**
-     * [OPTIONAL, Sink Configuration] BigQuery INTERVAL literal used as max_staleness when
-     * auto-creating a CDC destination table.
+     * [OPTIONAL, Sink Configuration] BigQuery INTERVAL literal intended to be used as max_staleness
+     * when auto-creating a CDC destination table.
+     *
+     * <p>Known limitation: BigQuery's REST table-creation path currently does not persist this
+     * option for CDC tables, even though table creation itself succeeds. As a result, max_staleness
+     * will remain unset after auto-creation.
+     *
+     * <p>Workaround: After the connector creates the table, run an ALTER TABLE statement such as:
+     *
+     * <p>{@code ALTER TABLE `project.dataset.table` SET OPTIONS ( max_staleness = INTERVAL 10
+     * MINUTE )}
      */
     public static final ConfigOption<String> CDC_MAX_STALENESS =
             ConfigOptions.key("write.cdc-max-staleness")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "BigQuery INTERVAL literal for max_staleness when the connector "
-                                    + "auto-creates a CDC destination table, for example "
-                                    + "INTERVAL 10 MINUTE.");
+                            "BigQuery INTERVAL literal intended for max_staleness when the "
+                                    + "connector auto-creates a CDC destination table, for "
+                                    + "example INTERVAL 10 MINUTE. Known limitation: due to a "
+                                    + "BigQuery REST API limitation, this option is currently not "
+                                    + "persisted during table creation, so max_staleness remains "
+                                    + "unset after create. Run ALTER TABLE ... SET OPTIONS "
+                                    + "(max_staleness = INTERVAL ...) after creation.");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -233,4 +233,26 @@ public class BigQueryConnectorOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Fail if serializer cannot convert record to proto");
+
+    /**
+     * [OPTIONAL, Sink Configuration] Enable CDC (Change Data Capture) for upsert/delete support.
+     * Requires AT_LEAST_ONCE delivery guarantee. The destination table must have a PRIMARY KEY.
+     */
+    public static final ConfigOption<Boolean> CDC_ENABLED =
+            ConfigOptions.key("write.cdc-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Enable CDC for upsert/delete. Requires AT_LEAST_ONCE. Table must have PRIMARY KEY.");
+
+    /**
+     * [OPTIONAL, Sink Configuration] Field name to use for CDC sequence number ordering. Required
+     * when CDC is enabled. Supports LONG, INT, TIMESTAMP types.
+     */
+    public static final ConfigOption<String> CDC_SEQUENCE_FIELD =
+            ConfigOptions.key("write.cdc-sequence-field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Field for CDC sequence number (required when CDC enabled). Supports LONG, INT, TIMESTAMP.");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -256,4 +256,29 @@ public class BigQueryConnectorOptions {
                     .withDescription(
                             "Optional field for CDC sequence number ordering. Supports LONG, INT, TIMESTAMP. "
                                     + "If omitted, the connector will not populate _change_sequence_number.");
+
+    /**
+     * [OPTIONAL, Sink Configuration] Comma-separated list of BigQuery primary key columns to apply
+     * when auto-creating a CDC destination table.
+     */
+    public static final ConfigOption<String> CDC_PRIMARY_KEY_COLUMNS =
+            ConfigOptions.key("write.cdc-primary-key-columns")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Comma-separated list of primary key columns to apply when the connector "
+                                    + "auto-creates a CDC destination table.");
+
+    /**
+     * [OPTIONAL, Sink Configuration] BigQuery INTERVAL literal used as max_staleness when
+     * auto-creating a CDC destination table.
+     */
+    public static final ConfigOption<String> CDC_MAX_STALENESS =
+            ConfigOptions.key("write.cdc-max-staleness")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "BigQuery INTERVAL literal for max_staleness when the connector "
+                                    + "auto-creates a CDC destination table, for example "
+                                    + "INTERVAL 10 MINUTE.");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -246,13 +246,14 @@ public class BigQueryConnectorOptions {
                             "Enable CDC for upsert/delete. Requires AT_LEAST_ONCE. Table must have PRIMARY KEY.");
 
     /**
-     * [OPTIONAL, Sink Configuration] Field name to use for CDC sequence number ordering. Required
-     * when CDC is enabled. Supports LONG, INT, TIMESTAMP types.
+     * [OPTIONAL, Sink Configuration] Field name to use for CDC sequence number ordering. Supports
+     * LONG, INT, TIMESTAMP types.
      */
     public static final ConfigOption<String> CDC_SEQUENCE_FIELD =
             ConfigOptions.key("write.cdc-sequence-field")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Field for CDC sequence number (required when CDC enabled). Supports LONG, INT, TIMESTAMP.");
+                            "Optional field for CDC sequence number ordering. Supports LONG, INT, TIMESTAMP. "
+                                    + "If omitted, the connector will not populate _change_sequence_number.");
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -100,6 +100,14 @@ public class BigQueryTableConfigurationProvider {
         return config.get(BigQueryConnectorOptions.FATALIZE_SERIALIZER);
     }
 
+    public boolean isCdcEnabled() {
+        return config.get(BigQueryConnectorOptions.CDC_ENABLED);
+    }
+
+    public Optional<String> getCdcSequenceField() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD));
+    }
+
     public BigQueryReadOptions toBigQueryReadOptions() {
         return BigQueryReadOptions.builder()
                 .setSnapshotTimestampInMillis(

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * A BigQuery Configuration class which can be used to transform to the option objects the source
@@ -106,6 +107,22 @@ public class BigQueryTableConfigurationProvider {
 
     public Optional<String> getCdcSequenceField() {
         return Optional.ofNullable(config.get(BigQueryConnectorOptions.CDC_SEQUENCE_FIELD));
+    }
+
+    public Optional<List<String>> getCdcPrimaryKeyColumns() {
+        String primaryKeyColumns = config.get(BigQueryConnectorOptions.CDC_PRIMARY_KEY_COLUMNS);
+        if (primaryKeyColumns == null) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                Arrays.stream(primaryKeyColumns.split(","))
+                        .map(String::trim)
+                        .filter(entry -> !entry.isEmpty())
+                        .collect(Collectors.toList()));
+    }
+
+    public Optional<String> getCdcMaxStaleness() {
+        return Optional.ofNullable(config.get(BigQueryConnectorOptions.CDC_MAX_STALENESS));
     }
 
     public BigQueryReadOptions toBigQueryReadOptions() {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.sink.serializer.AvroToProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQueryProtoSerializer;
 import com.google.cloud.flink.bigquery.sink.serializer.BigQuerySchemaProvider;
+import com.google.cloud.flink.bigquery.sink.serializer.CdcChangeTypeProvider;
 import com.google.cloud.flink.bigquery.sink.serializer.TestSchemaProvider;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.Test;
@@ -38,6 +39,7 @@ import static com.google.cloud.flink.bigquery.RestartStrategyConfigUtils.noResta
 import static com.google.cloud.flink.bigquery.sink.BigQuerySinkConfig.validateStreamExecutionEnvironment;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -245,6 +247,111 @@ public class BigQuerySinkConfigTest {
         try (StreamExecutionEnvironment env =
                 new StreamExecutionEnvironment(noRestartStrategyConfig())) {
             validateStreamExecutionEnvironment(env);
+        }
+    }
+
+    // ---------- CDC Configuration Tests ----------
+
+    @Test
+    public void testCdcConfiguration() throws Exception {
+        BigQueryConnectOptions connectOptions =
+                BigQueryConnectOptions.builder()
+                        .setProjectId("project")
+                        .setDataset("dataset")
+                        .setTable("table")
+                        .build();
+        BigQuerySchemaProvider schemaProvider = new TestSchemaProvider(null, null);
+        BigQueryProtoSerializer<GenericRecord> serializer = new AvroToProtoSerializer();
+        CdcChangeTypeProvider<GenericRecord> changeTypeProvider =
+                CdcChangeTypeProvider.upsertOnly();
+
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(
+                        fixedDelayRestartStrategyConfig(5, Duration.ofSeconds(5)))) {
+            BigQuerySinkConfig<GenericRecord> sinkConfig =
+                    BigQuerySinkConfig.<GenericRecord>newBuilder()
+                            .connectOptions(connectOptions)
+                            .schemaProvider(schemaProvider)
+                            .serializer(serializer)
+                            .streamExecutionEnvironment(env)
+                            .deliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+                            .enableCdc(true)
+                            .cdcSequenceField("timestamp_field")
+                            .cdcChangeTypeProvider(changeTypeProvider)
+                            .build();
+
+            assertTrue(sinkConfig.isCdcEnabled());
+            assertEquals("timestamp_field", sinkConfig.getCdcSequenceField());
+            assertNotNull(sinkConfig.getCdcChangeTypeProvider());
+            assertEquals("UPSERT", sinkConfig.getCdcChangeTypeProvider().getChangeType(null));
+        }
+    }
+
+    @Test
+    public void testCdcConfiguration_defaults() throws Exception {
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(
+                        fixedDelayRestartStrategyConfig(5, Duration.ofSeconds(5)))) {
+            BigQuerySinkConfig<?> sinkConfig =
+                    BigQuerySinkConfig.newBuilder().streamExecutionEnvironment(env).build();
+
+            assertFalse(sinkConfig.isCdcEnabled());
+            assertNull(sinkConfig.getCdcSequenceField());
+            assertNull(sinkConfig.getCdcChangeTypeProvider());
+        }
+    }
+
+    @Test
+    public void testCdcConfiguration_withCustomChangeTypeProvider() throws Exception {
+        BigQueryConnectOptions connectOptions =
+                BigQueryConnectOptions.builder()
+                        .setProjectId("project")
+                        .setDataset("dataset")
+                        .setTable("table")
+                        .build();
+        BigQuerySchemaProvider schemaProvider = new TestSchemaProvider(null, null);
+        BigQueryProtoSerializer<String> serializer =
+                new BigQueryProtoSerializer<String>() {
+                    @Override
+                    public void init(BigQuerySchemaProvider schemaProvider) {}
+
+                    @Override
+                    public com.google.protobuf.ByteString serialize(String record) {
+                        return com.google.protobuf.ByteString.copyFromUtf8(record);
+                    }
+
+                    @Override
+                    public org.apache.avro.Schema getAvroSchema(String record) {
+                        return null;
+                    }
+                };
+
+        CdcChangeTypeProvider<String> customProvider =
+                record -> {
+                    if (record != null && record.startsWith("DELETE:")) {
+                        return "DELETE";
+                    }
+                    return "UPSERT";
+                };
+
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(noRestartStrategyConfig())) {
+            BigQuerySinkConfig<String> sinkConfig =
+                    BigQuerySinkConfig.<String>newBuilder()
+                            .connectOptions(connectOptions)
+                            .schemaProvider(schemaProvider)
+                            .serializer(serializer)
+                            .streamExecutionEnvironment(env)
+                            .deliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+                            .enableCdc(true)
+                            .cdcChangeTypeProvider(customProvider)
+                            .build();
+
+            assertTrue(sinkConfig.isCdcEnabled());
+            CdcChangeTypeProvider<String> provider =
+                    (CdcChangeTypeProvider<String>) sinkConfig.getCdcChangeTypeProvider();
+            assertEquals("UPSERT", provider.getChangeType("INSERT:data"));
+            assertEquals("DELETE", provider.getChangeType("DELETE:data"));
         }
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkConfigTest.java
@@ -277,11 +277,16 @@ public class BigQuerySinkConfigTest {
                             .deliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
                             .enableCdc(true)
                             .cdcSequenceField("timestamp_field")
+                            .cdcPrimaryKeyColumns(Arrays.asList("shop_id", "event_date"))
+                            .cdcMaxStaleness("INTERVAL 10 MINUTE")
                             .cdcChangeTypeProvider(changeTypeProvider)
                             .build();
 
             assertTrue(sinkConfig.isCdcEnabled());
             assertEquals("timestamp_field", sinkConfig.getCdcSequenceField());
+            assertEquals(
+                    Arrays.asList("shop_id", "event_date"), sinkConfig.getCdcPrimaryKeyColumns());
+            assertEquals("INTERVAL 10 MINUTE", sinkConfig.getCdcMaxStaleness());
             assertNotNull(sinkConfig.getCdcChangeTypeProvider());
             assertEquals("UPSERT", sinkConfig.getCdcChangeTypeProvider().getChangeType(null));
         }
@@ -297,6 +302,8 @@ public class BigQuerySinkConfigTest {
 
             assertFalse(sinkConfig.isCdcEnabled());
             assertNull(sinkConfig.getCdcSequenceField());
+            assertNull(sinkConfig.getCdcPrimaryKeyColumns());
+            assertNull(sinkConfig.getCdcMaxStaleness());
             assertNull(sinkConfig.getCdcChangeTypeProvider());
         }
     }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
@@ -162,8 +162,9 @@ public class BigQuerySinkTest {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testGet_withCdcTableAutoCreation_withoutMaxStaleness_shouldFail() throws Exception {
+    @Test
+    public void testGet_withCdcTableAutoCreation_withoutMaxStaleness_shouldSucceed()
+            throws Exception {
         try (StreamExecutionEnvironment env =
                 new StreamExecutionEnvironment(noRestartStrategyConfig())) {
             BigQuerySinkConfig<Object> sinkConfig =
@@ -177,7 +178,7 @@ public class BigQuerySinkTest {
                             .enableTableCreation(true)
                             .cdcPrimaryKeyColumns(java.util.Arrays.asList("shop_id"))
                             .build();
-            BigQuerySink.get(sinkConfig);
+            assertTrue(BigQuerySink.get(sinkConfig) instanceof BigQueryDefaultSink);
         }
     }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
@@ -126,6 +126,23 @@ public class BigQuerySinkTest {
         }
     }
 
+    @Test
+    public void testGet_withCdcEnabled_atLeastOnce_withoutSequenceField() throws Exception {
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(noRestartStrategyConfig())) {
+            BigQuerySinkConfig<Object> sinkConfig =
+                    BigQuerySinkConfig.<Object>newBuilder()
+                            .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                            .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
+                            .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
+                            .deliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+                            .streamExecutionEnvironment(env)
+                            .enableCdc(true)
+                            .build();
+            assertTrue(BigQuerySink.get(sinkConfig) instanceof BigQueryDefaultSink);
+        }
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testGet_withCdcEnabled_exactlyOnce_shouldFail() throws Exception {
         try (StreamExecutionEnvironment env =

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
@@ -144,6 +144,44 @@ public class BigQuerySinkTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void testGet_withCdcTableAutoCreation_withoutPrimaryKeys_shouldFail() throws Exception {
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(noRestartStrategyConfig())) {
+            BigQuerySinkConfig<Object> sinkConfig =
+                    BigQuerySinkConfig.<Object>newBuilder()
+                            .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                            .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
+                            .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
+                            .deliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+                            .streamExecutionEnvironment(env)
+                            .enableCdc(true)
+                            .enableTableCreation(true)
+                            .cdcMaxStaleness("INTERVAL 10 MINUTE")
+                            .build();
+            BigQuerySink.get(sinkConfig);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGet_withCdcTableAutoCreation_withoutMaxStaleness_shouldFail() throws Exception {
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(noRestartStrategyConfig())) {
+            BigQuerySinkConfig<Object> sinkConfig =
+                    BigQuerySinkConfig.<Object>newBuilder()
+                            .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                            .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
+                            .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
+                            .deliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+                            .streamExecutionEnvironment(env)
+                            .enableCdc(true)
+                            .enableTableCreation(true)
+                            .cdcPrimaryKeyColumns(java.util.Arrays.asList("shop_id"))
+                            .build();
+            BigQuerySink.get(sinkConfig);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testGet_withCdcEnabled_exactlyOnce_shouldFail() throws Exception {
         try (StreamExecutionEnvironment env =
                 new StreamExecutionEnvironment(noRestartStrategyConfig())) {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/BigQuerySinkTest.java
@@ -107,4 +107,56 @@ public class BigQuerySinkTest {
             assertTrue(BigQuerySink.get(sinkConfig) instanceof BigQueryExactlyOnceSink);
         }
     }
+
+    @Test
+    public void testGet_withCdcEnabled_atLeastOnce() throws Exception {
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(noRestartStrategyConfig())) {
+            BigQuerySinkConfig<Object> sinkConfig =
+                    BigQuerySinkConfig.<Object>newBuilder()
+                            .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                            .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
+                            .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
+                            .deliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+                            .streamExecutionEnvironment(env)
+                            .enableCdc(true)
+                            .cdcSequenceField("timestamp")
+                            .build();
+            assertTrue(BigQuerySink.get(sinkConfig) instanceof BigQueryDefaultSink);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGet_withCdcEnabled_exactlyOnce_shouldFail() throws Exception {
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(noRestartStrategyConfig())) {
+            BigQuerySinkConfig<Object> sinkConfig =
+                    BigQuerySinkConfig.<Object>newBuilder()
+                            .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                            .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
+                            .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
+                            .deliveryGuarantee(DeliveryGuarantee.EXACTLY_ONCE)
+                            .streamExecutionEnvironment(env)
+                            .enableCdc(true)
+                            .build();
+            BigQuerySink.get(sinkConfig);
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGet_withCdcEnabled_noneDeliveryGuarantee_shouldFail() throws Exception {
+        try (StreamExecutionEnvironment env =
+                new StreamExecutionEnvironment(noRestartStrategyConfig())) {
+            BigQuerySinkConfig<Object> sinkConfig =
+                    BigQuerySinkConfig.<Object>newBuilder()
+                            .connectOptions(StorageClientFaker.createConnectOptionsForWrite(null))
+                            .schemaProvider(TestBigQuerySchemas.getSimpleRecordSchema())
+                            .serializer(new FakeBigQuerySerializer(ByteString.copyFromUtf8("foo")))
+                            .deliveryGuarantee(DeliveryGuarantee.NONE)
+                            .streamExecutionEnvironment(env)
+                            .enableCdc(true)
+                            .build();
+            BigQuerySink.get(sinkConfig);
+        }
+    }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/client/BigQueryClientWithErrorHandlingTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/client/BigQueryClientWithErrorHandlingTest.java
@@ -16,10 +16,15 @@
 
 package com.google.cloud.flink.bigquery.sink.client;
 
+import com.google.api.services.bigquery.model.Table;
 import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.flink.bigquery.common.config.BigQueryConnectOptions;
 import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
 import com.google.cloud.flink.bigquery.fakes.StorageClientFaker;
+import com.google.cloud.flink.bigquery.sink.writer.CreateTableOptions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -86,7 +91,13 @@ public class BigQueryClientWithErrorHandlingTest {
         BigQueryConnectorException exception =
                 assertThrows(
                         BigQueryConnectorException.class,
-                        () -> BigQueryClientWithErrorHandling.createTable(options, null));
+                        () ->
+                                BigQueryClientWithErrorHandling.createTable(
+                                        options,
+                                        null,
+                                        new CreateTableOptions(
+                                                false, null, null, null, null, null, false, null,
+                                                null)));
         assertThat(exception).hasMessageThat().contains("Unable to create BigQuery table");
     }
 
@@ -95,6 +106,46 @@ public class BigQueryClientWithErrorHandlingTest {
         when(mockedException.getCode()).thenReturn(409);
         BigQueryConnectOptions options =
                 StorageClientFaker.createConnectOptionsForQuery(false, null, null, mockedException);
-        BigQueryClientWithErrorHandling.createTable(options, null);
+        BigQueryClientWithErrorHandling.createTable(
+                options,
+                null,
+                new CreateTableOptions(false, null, null, null, null, null, false, null, null));
+    }
+
+    @Test
+    public void testToCdcTable() {
+        BigQueryConnectOptions options =
+                BigQueryConnectOptions.builder()
+                        .setProjectId("project")
+                        .setDataset("dataset")
+                        .setTable("table")
+                        .build();
+        StandardTableDefinition tableDefinition =
+                StandardTableDefinition.newBuilder()
+                        .setSchema(
+                                Schema.of(
+                                        com.google.cloud.bigquery.Field.of(
+                                                "shop_id", StandardSQLTypeName.INT64)))
+                        .build();
+
+        Table table =
+                BigQueryClientWithErrorHandling.toCdcTable(
+                        options,
+                        tableDefinition,
+                        new CreateTableOptions(
+                                true,
+                                null,
+                                null,
+                                null,
+                                null,
+                                null,
+                                true,
+                                java.util.Arrays.asList("shop_id"),
+                                "INTERVAL 10 MINUTE"));
+
+        assertThat(table.getTableReference().getProjectId()).isEqualTo("project");
+        assertThat(table.getTableConstraints().getPrimaryKey().getColumns())
+                .containsExactly("shop_id");
+        assertThat(table.getMaxStaleness()).isEqualTo("INTERVAL 10 MINUTE");
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializerCdcTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/AvroToProtoSerializerCdcTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.serializer;
+
+import com.google.cloud.flink.bigquery.sink.exceptions.BigQuerySerializationException;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.joda.time.Instant;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for CDC (Change Data Capture) functionality in {@link AvroToProtoSerializer}. */
+public class AvroToProtoSerializerCdcTest {
+
+    @Test
+    public void testSerializeWithCdc_upsert()
+            throws BigQuerySerializationException, InvalidProtocolBufferException {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.initForCdc(cdcProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("long_field", 12345L)
+                        .set("string_field", "test_value")
+                        .build();
+
+        ByteString result = serializer.serializeWithCdc(record, "UPSERT", "0000000000000001");
+
+        Descriptor cdcDescriptor = cdcProvider.getDescriptor();
+        DynamicMessage message = DynamicMessage.parseFrom(cdcDescriptor, result);
+
+        assertEquals(12345L, message.getField(cdcDescriptor.findFieldByName("long_field")));
+        assertEquals("test_value", message.getField(cdcDescriptor.findFieldByName("string_field")));
+
+        assertEquals(
+                "UPSERT",
+                message.getField(
+                        cdcDescriptor.findFieldByName(
+                                BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD)));
+        assertEquals(
+                "0000000000000001",
+                message.getField(
+                        cdcDescriptor.findFieldByName(
+                                BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD)));
+    }
+
+    @Test
+    public void testSerializeWithCdc_delete()
+            throws BigQuerySerializationException, InvalidProtocolBufferException {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.initForCdc(cdcProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("long_field", 99999L)
+                        .set("string_field", "to_be_deleted")
+                        .build();
+
+        ByteString result = serializer.serializeWithCdc(record, "DELETE", "0000000000000002");
+
+        Descriptor cdcDescriptor = cdcProvider.getDescriptor();
+        DynamicMessage message = DynamicMessage.parseFrom(cdcDescriptor, result);
+
+        assertEquals(
+                "DELETE",
+                message.getField(
+                        cdcDescriptor.findFieldByName(
+                                BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD)));
+        assertEquals(
+                "0000000000000002",
+                message.getField(
+                        cdcDescriptor.findFieldByName(
+                                BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD)));
+    }
+
+    @Test
+    public void testExtractSequenceNumber_fromLong() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(baseProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("long_field", 123456789L)
+                        .set("string_field", "test")
+                        .build();
+
+        String sequenceNumber = serializer.extractSequenceNumber(record, "long_field");
+
+        assertEquals(16, sequenceNumber.length());
+        assertEquals("00000000075BCD15", sequenceNumber);
+    }
+
+    @Test
+    public void testExtractSequenceNumber_fromInteger() {
+        String fieldString =
+                "\"fields\": "
+                        + "["
+                        + "{\"name\": \"int_field\", \"type\": \"int\"},"
+                        + "{\"name\": \"string_field\", \"type\": \"string\"}"
+                        + "]";
+        Schema avroSchema = TestBigQuerySchemas.getAvroSchemaFromFieldString(fieldString);
+        BigQuerySchemaProvider provider = new BigQuerySchemaProviderImpl(avroSchema);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(provider);
+
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("int_field", 255)
+                        .set("string_field", "test")
+                        .build();
+
+        String sequenceNumber = serializer.extractSequenceNumber(record, "int_field");
+
+        assertEquals(16, sequenceNumber.length());
+        assertEquals("00000000000000FF", sequenceNumber);
+    }
+
+    @Test
+    public void testExtractSequenceNumber_fromJodaInstant() {
+        String fieldString =
+                " \"fields\": [\n"
+                        + "   {\"name\": \"ts_millis\", \"type\": {\"type\": \"long\", \"logicalType\": \"timestamp-millis\"}},\n"
+                        + "   {\"name\": \"name\", \"type\": \"string\"}\n"
+                        + " ]\n";
+        Schema avroSchema = TestBigQuerySchemas.getAvroSchemaFromFieldString(fieldString);
+        BigQuerySchemaProvider provider = new BigQuerySchemaProviderImpl(avroSchema);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(provider);
+
+        Instant jodaInstant = new Instant(1710943144787L);
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("ts_millis", jodaInstant)
+                        .set("name", "test")
+                        .build();
+
+        String sequenceNumber = serializer.extractSequenceNumber(record, "ts_millis");
+
+        assertEquals(16, sequenceNumber.length());
+        long parsedValue = Long.parseUnsignedLong(sequenceNumber, 16);
+        assertEquals(1710943144787L, parsedValue);
+    }
+
+    @Test
+    public void testExtractSequenceNumber_fromJavaInstant() {
+        String fieldString =
+                "\"fields\": "
+                        + "["
+                        + "{\"name\": \"timestamp_field\", \"type\": \"long\"},"
+                        + "{\"name\": \"name\", \"type\": \"string\"}"
+                        + "]";
+        Schema avroSchema = TestBigQuerySchemas.getAvroSchemaFromFieldString(fieldString);
+        BigQuerySchemaProvider provider = new BigQuerySchemaProviderImpl(avroSchema);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(provider);
+
+        java.time.Instant javaInstant = java.time.Instant.ofEpochMilli(1710943144787L);
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("timestamp_field", javaInstant.toEpochMilli())
+                        .set("name", "test")
+                        .build();
+
+        String sequenceNumber = serializer.extractSequenceNumber(record, "timestamp_field");
+
+        assertEquals(16, sequenceNumber.length());
+    }
+
+    @Test
+    public void testExtractSequenceNumber_nullFieldValue_returnsNull() {
+        String fieldString =
+                "\"fields\": "
+                        + "["
+                        + "{\"name\": \"nullable_long\", \"type\": [\"null\", \"long\"]},"
+                        + "{\"name\": \"name\", \"type\": \"string\"}"
+                        + "]";
+        Schema avroSchema = TestBigQuerySchemas.getAvroSchemaFromFieldString(fieldString);
+        BigQuerySchemaProvider provider = new BigQuerySchemaProviderImpl(avroSchema);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(provider);
+
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("nullable_long", null)
+                        .set("name", "test")
+                        .build();
+
+        String sequenceNumber = serializer.extractSequenceNumber(record, "nullable_long");
+
+        assertNull(sequenceNumber);
+    }
+
+    @Test
+    public void testExtractSequenceNumber_nullSequenceFieldParam_returnsNull() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(baseProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("long_field", 123L)
+                        .set("string_field", "test")
+                        .build();
+
+        assertNull(serializer.extractSequenceNumber(record, null));
+        assertNull(serializer.extractSequenceNumber(record, ""));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExtractSequenceNumber_missingField_throwsException() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(baseProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("long_field", 123L)
+                        .set("string_field", "test")
+                        .build();
+
+        serializer.extractSequenceNumber(record, "nonexistent_field");
+    }
+
+    @Test
+    public void testSerializeWithCdc_complexSchema()
+            throws BigQuerySerializationException, InvalidProtocolBufferException {
+        BigQuerySchemaProvider baseProvider =
+                TestBigQuerySchemas.getSchemaWithRequiredPrimitiveTypes();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.initForCdc(cdcProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        Schema nestedSchema = avroSchema.getField("required_record_field").schema();
+        GenericRecord nestedRecord =
+                new GenericRecordBuilder(nestedSchema).set("species", "Eagle").build();
+
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("number", 42L)
+                        .set("price", 3.14)
+                        .set("species", "Bird")
+                        .set("flighted", true)
+                        .set("sound", java.nio.ByteBuffer.wrap(new byte[] {1, 2, 3}))
+                        .set("required_record_field", nestedRecord)
+                        .build();
+
+        ByteString result = serializer.serializeWithCdc(record, "UPSERT", "ABCD1234");
+
+        Descriptor cdcDescriptor = cdcProvider.getDescriptor();
+        DynamicMessage message = DynamicMessage.parseFrom(cdcDescriptor, result);
+
+        FieldDescriptor changeTypeField =
+                cdcDescriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD);
+        FieldDescriptor sequenceField =
+                cdcDescriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD);
+
+        assertNotNull(changeTypeField);
+        assertNotNull(sequenceField);
+        assertEquals("UPSERT", message.getField(changeTypeField));
+        assertEquals("ABCD1234", message.getField(sequenceField));
+    }
+
+    @Test
+    public void testInitForCdc_setsUpDescriptorCorrectly() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.initForCdc(cdcProvider);
+
+        assertTrue("Serializer should be initialized for CDC", true);
+    }
+
+    @Test
+    public void testExtractSequenceNumber_stringNumericValue_convertsToHex() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(baseProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("long_field", 123L)
+                        .set("string_field", "12345")
+                        .build();
+
+        String sequenceNumber = serializer.extractSequenceNumber(record, "string_field");
+
+        assertEquals(16, sequenceNumber.length());
+        assertEquals("0000000000003039", sequenceNumber);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testExtractSequenceNumber_nonNumericString_throwsException() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        AvroToProtoSerializer serializer = new AvroToProtoSerializer();
+        serializer.init(baseProvider);
+
+        Schema avroSchema = baseProvider.getAvroSchema();
+        GenericRecord record =
+                new GenericRecordBuilder(avroSchema)
+                        .set("long_field", 123L)
+                        .set("string_field", "not_a_number")
+                        .build();
+
+        serializer.extractSequenceNumber(record, "string_field");
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryCdcSchemaProviderTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryCdcSchemaProviderTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.serializer;
+
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import org.apache.avro.Schema;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link BigQueryCdcSchemaProvider}. */
+public class BigQueryCdcSchemaProviderTest {
+
+    @Test
+    public void testCdcSchemaAugmentation() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        assertFalse(cdcProvider.schemaUnknown());
+
+        Schema avroSchema = cdcProvider.getAvroSchema();
+        assertNotNull(avroSchema);
+
+        assertNotNull(avroSchema.getField("long_field"));
+        assertNotNull(avroSchema.getField("string_field"));
+
+        Schema.Field changeTypeField =
+                avroSchema.getField(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD);
+        assertNotNull(changeTypeField);
+        assertTrue(changeTypeField.schema().isUnion());
+
+        Schema.Field sequenceNumberField =
+                avroSchema.getField(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD);
+        assertNotNull(sequenceNumberField);
+        assertTrue(sequenceNumberField.schema().isUnion());
+    }
+
+    @Test
+    public void testCdcDescriptorAugmentation() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        Descriptor descriptor = cdcProvider.getDescriptor();
+        assertNotNull(descriptor);
+
+        FieldDescriptor longField = descriptor.findFieldByName("long_field");
+        assertNotNull(longField);
+        assertEquals(FieldDescriptor.Type.INT64, longField.getType());
+
+        FieldDescriptor stringField = descriptor.findFieldByName("string_field");
+        assertNotNull(stringField);
+        assertEquals(FieldDescriptor.Type.STRING, stringField.getType());
+
+        FieldDescriptor changeTypeField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD);
+        assertNotNull(changeTypeField);
+        assertEquals(FieldDescriptor.Type.STRING, changeTypeField.getType());
+        assertTrue(changeTypeField.isOptional());
+
+        FieldDescriptor sequenceNumberField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD);
+        assertNotNull(sequenceNumberField);
+        assertEquals(FieldDescriptor.Type.STRING, sequenceNumberField.getType());
+        assertTrue(sequenceNumberField.isOptional());
+    }
+
+    @Test
+    public void testCdcDescriptorProtoAugmentation() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        int baseFieldCount = baseProvider.getDescriptorProto().getFieldCount();
+
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+        int cdcFieldCount = cdcProvider.getDescriptorProto().getFieldCount();
+
+        assertEquals(baseFieldCount + 2, cdcFieldCount);
+
+        boolean foundChangeType = false;
+        boolean foundSequenceNumber = false;
+        for (FieldDescriptorProto field : cdcProvider.getDescriptorProto().getFieldList()) {
+            if (field.getName().equals(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD)) {
+                foundChangeType = true;
+                assertEquals(FieldDescriptorProto.Type.TYPE_STRING, field.getType());
+                assertEquals(FieldDescriptorProto.Label.LABEL_OPTIONAL, field.getLabel());
+            }
+            if (field.getName().equals(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD)) {
+                foundSequenceNumber = true;
+                assertEquals(FieldDescriptorProto.Type.TYPE_STRING, field.getType());
+                assertEquals(FieldDescriptorProto.Label.LABEL_OPTIONAL, field.getLabel());
+            }
+        }
+        assertTrue("_change_type field should be present", foundChangeType);
+        assertTrue("_change_sequence_number field should be present", foundSequenceNumber);
+    }
+
+    @Test
+    public void testCdcFieldNumbers() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        int maxBaseFieldNumber = 0;
+        for (FieldDescriptorProto field : baseProvider.getDescriptorProto().getFieldList()) {
+            maxBaseFieldNumber = Math.max(maxBaseFieldNumber, field.getNumber());
+        }
+
+        Descriptor descriptor = cdcProvider.getDescriptor();
+        FieldDescriptor changeTypeField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD);
+        FieldDescriptor sequenceNumberField =
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD);
+
+        assertEquals(maxBaseFieldNumber + 1, changeTypeField.getNumber());
+        assertEquals(maxBaseFieldNumber + 2, sequenceNumberField.getNumber());
+    }
+
+    @Test
+    public void testCdcSchemaProviderWithUnknownSchema() {
+        BigQuerySchemaProvider baseProvider = new TestSchemaProvider(null, null);
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        assertTrue(cdcProvider.schemaUnknown());
+        assertNull(cdcProvider.getAvroSchema());
+        assertNull(cdcProvider.getDescriptor());
+        assertNull(cdcProvider.getDescriptorProto());
+    }
+
+    @Test
+    public void testCdcSchemaProviderEquality() {
+        BigQuerySchemaProvider baseProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+
+        BigQueryCdcSchemaProvider cdcProvider1 = new BigQueryCdcSchemaProvider(baseProvider);
+        BigQueryCdcSchemaProvider cdcProvider2 = new BigQueryCdcSchemaProvider(baseProvider);
+
+        assertEquals(cdcProvider1, cdcProvider2);
+        assertEquals(cdcProvider1.hashCode(), cdcProvider2.hashCode());
+    }
+
+    @Test
+    public void testCdcSchemaProviderWithComplexSchema() {
+        BigQuerySchemaProvider baseProvider =
+                TestBigQuerySchemas.getSchemaWithRequiredPrimitiveTypes();
+        BigQueryCdcSchemaProvider cdcProvider = new BigQueryCdcSchemaProvider(baseProvider);
+
+        Schema avroSchema = cdcProvider.getAvroSchema();
+        assertNotNull(avroSchema.getField("number"));
+        assertNotNull(avroSchema.getField("price"));
+        assertNotNull(avroSchema.getField("species"));
+        assertNotNull(avroSchema.getField("flighted"));
+        assertNotNull(avroSchema.getField("sound"));
+        assertNotNull(avroSchema.getField("required_record_field"));
+
+        assertNotNull(avroSchema.getField(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD));
+        assertNotNull(avroSchema.getField(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD));
+
+        Descriptor descriptor = cdcProvider.getDescriptor();
+        assertNotNull(descriptor.findFieldByName("number"));
+        assertNotNull(descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_CHANGE_TYPE_FIELD));
+        assertNotNull(
+                descriptor.findFieldByName(BigQueryCdcSchemaProvider.CDC_SEQUENCE_NUMBER_FIELD));
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializerTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/BigQueryProtoSerializerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.serializer;
+
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThrows;
+
+/** Tests for {@link BigQueryProtoSerializer}. */
+public class BigQueryProtoSerializerTest {
+
+    private final BigQueryProtoSerializer<String> serializer =
+            new BigQueryProtoSerializer<String>() {
+                @Override
+                public ByteString serialize(String record) {
+                    return ByteString.copyFromUtf8(record);
+                }
+
+                @Override
+                public org.apache.avro.Schema getAvroSchema(String record) {
+                    return null;
+                }
+            };
+
+    @Test
+    public void extractSequenceNumber_withoutOverride_shouldThrow() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> serializer.extractSequenceNumber("record", "sequence_field"));
+    }
+
+    @Test
+    public void serializeWithCdc_withoutOverride_shouldThrow() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> serializer.serializeWithCdc("record", "UPSERT", "0000000000000001"));
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/CdcChangeTypeProviderTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/serializer/CdcChangeTypeProviderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.flink.bigquery.sink.serializer;
+
+import org.apache.avro.generic.GenericRecord;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link CdcChangeTypeProvider}. */
+public class CdcChangeTypeProviderTest {
+
+    @Test
+    public void testUpsertOnly_returnsUpsertForAnyRecord() {
+        CdcChangeTypeProvider<GenericRecord> provider = CdcChangeTypeProvider.upsertOnly();
+        assertEquals("UPSERT", provider.getChangeType(null));
+    }
+
+    @Test
+    public void testCustomProvider_returnsCorrectChangeType() {
+        CdcChangeTypeProvider<String> provider =
+                record -> {
+                    if (record != null && record.startsWith("DELETE:")) {
+                        return "DELETE";
+                    }
+                    return "UPSERT";
+                };
+        assertEquals("UPSERT", provider.getChangeType("INSERT:data"));
+        assertEquals("DELETE", provider.getChangeType("DELETE:data"));
+    }
+
+    @Test
+    public void testUpsertOnly_withRecord() {
+        BigQuerySchemaProvider schemaProvider = TestBigQuerySchemas.getSimpleRecordSchema();
+        GenericRecord record =
+                new org.apache.avro.generic.GenericRecordBuilder(schemaProvider.getAvroSchema())
+                        .set("long_field", 123L)
+                        .set("string_field", "test")
+                        .build();
+
+        CdcChangeTypeProvider<GenericRecord> provider = CdcChangeTypeProvider.upsertOnly();
+        assertEquals("UPSERT", provider.getChangeType(record));
+    }
+}

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryBufferedWriterTest.java
@@ -522,7 +522,8 @@ public class BigQueryBufferedWriterTest {
                         new FakeBigQuerySerializer(
                                 ByteString.copyFromUtf8("foobar"),
                                 StorageClientFaker.SIMPLE_AVRO_SCHEMA),
-                        new CreateTableOptions(true, null, null, null, null, null),
+                        new CreateTableOptions(
+                                true, null, null, null, null, null, false, null, null),
                         false);
         // First element will be added to append request.
         bufferedWriter.write(new Object(), null);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
@@ -413,6 +413,9 @@ public class BigQueryDefaultWriterTest {
                 false,
                 128,
                 "traceId",
+                false,
+                null,
+                null,
                 mockInitContext);
     }
 
@@ -427,6 +430,9 @@ public class BigQueryDefaultWriterTest {
                 fatalizeSerializer,
                 128,
                 "traceId",
+                false,
+                null,
+                null,
                 mockInitContext);
     }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/sink/writer/BigQueryDefaultWriterTest.java
@@ -164,7 +164,8 @@ public class BigQueryDefaultWriterTest {
                                 ByteString.copyFromUtf8("foobar"),
                                 StorageClientFaker.SIMPLE_AVRO_SCHEMA),
                         AppendRowsResponse.newBuilder().build(),
-                        new CreateTableOptions(true, null, null, null, null, null),
+                        new CreateTableOptions(
+                                true, null, null, null, null, null, false, null, null),
                         false);
         // First element will be added to append request.
         defaultWriter.write(new Object(), null);
@@ -186,7 +187,8 @@ public class BigQueryDefaultWriterTest {
                                 ByteString.copyFromUtf8("foobar"),
                                 StorageClientFaker.SIMPLE_AVRO_SCHEMA),
                         AppendRowsResponse.newBuilder().build(),
-                        new CreateTableOptions(false, null, null, null, null, null),
+                        new CreateTableOptions(
+                                false, null, null, null, null, null, false, null, null),
                         false);
         // First element will be added to append request.
         defaultWriter.write(new Object(), null);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableSinkTest.java
@@ -120,4 +120,37 @@ public class BigQueryDynamicTableSinkTest {
                 SinkV2Provider.class,
                 TABLE_SINK.getSinkRuntimeProvider(Mockito.mock(DynamicTableSink.Context.class)));
     }
+
+    @Test
+    public void testCdcConstructor() {
+        BigQueryDynamicTableSink cdcTableSink =
+                new BigQueryDynamicTableSink(
+                        StorageClientFaker.createConnectOptionsForWrite(null),
+                        DeliveryGuarantee.AT_LEAST_ONCE,
+                        SCHEMA,
+                        PARALLELISM,
+                        true,
+                        PARTITIONING_FIELD,
+                        TimePartitioning.Type.DAY,
+                        10000000000000L,
+                        CLUSTERED_FIELDS,
+                        REGION,
+                        true,
+                        true,
+                        "event_ts",
+                        Arrays.asList("shop_id", "event_date"),
+                        "INTERVAL 10 MINUTE",
+                        null);
+
+        BigQuerySinkConfig<RowData> obtainedSinkConfig = cdcTableSink.getSinkConfig();
+        assertTrue(obtainedSinkConfig.isCdcEnabled());
+        assertEquals("event_ts", obtainedSinkConfig.getCdcSequenceField());
+        assertEquals(
+                Arrays.asList("shop_id", "event_date"),
+                obtainedSinkConfig.getCdcPrimaryKeyColumns());
+        assertEquals("INTERVAL 10 MINUTE", obtainedSinkConfig.getCdcMaxStaleness());
+        assertEquals(
+                ChangelogMode.all(),
+                cdcTableSink.getChangelogMode(Mockito.mock(ChangelogMode.class)));
+    }
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,0 @@
-# JitPack build config: use Flink 2.1 profile, Java 17 for --release support
-jdk:
-  - openjdk17
-install:
-  - ./mvnw clean install -Pflink_2.1 -DskipTests -Dspotless.check.skip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+# JitPack build config: use Flink 2.1 profile (flink-2.1-connector-bigquery module)
+jitpack:
+  install: mvn clean install -Pflink_2.1 -DskipTests -Dspotless.check.skip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,5 @@
 # JitPack build config: use Flink 2.1 profile, Java 17 for --release support
 jdk:
   - openjdk17
-jitpack:
-  install: mvn clean install -Pflink_2.1 -DskipTests -Dspotless.check.skip
+install:
+  - ./mvnw clean install -Pflink_2.1 -DskipTests -Dspotless.check.skip

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,5 @@
-# JitPack build config: use Flink 2.1 profile (flink-2.1-connector-bigquery module)
+# JitPack build config: use Flink 2.1 profile, Java 17 for --release support
+jdk:
+  - openjdk17
 jitpack:
   install: mvn clean install -Pflink_2.1 -DskipTests -Dspotless.check.skip


### PR DESCRIPTION
## Summary
- Add upsert (changelog) support to bigquery connector for flink 2.1
- Based on https://github.com/GoogleCloudDataproc/flink-bigquery-connector/pull/262 
