### PR TITLE
Null-check unsupported function definitions in BigQueryRestriction.convert

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Release Notes
 
 ## Next
+* Null-check `BigQueryRestriction.convert`'s `FILTERS.get(...)` result so unsupported
+  function definitions (e.g. `COALESCE`, `CASE`, `IF`, `CAST`) inside a pushable
+  position return `Optional.empty()` instead of crashing job planning with a
+  `NullPointerException`. Previously, predicates like `NOT COALESCE(boolean_col, FALSE)`
+  would NPE during planning because the `NOT` case recurses through `convert` and the
+  inner switch unboxed a null `Operation`.
 
 ## 1.1.0 - 2026-02-11
 * PR #260: Upgrade dependencies versions.

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestriction.java
@@ -26,8 +26,6 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 
-import com.google.cloud.flink.bigquery.common.exceptions.BigQueryConnectorException;
-
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -105,6 +103,14 @@ public class BigQueryRestriction {
      * BETWEEN will be converted to (GT_EQ AND LT_EQ), the NOT_BETWEEN will be converted to (LT_EQ
      * OR GT_EQ), the IN will be converted to OR, so we do not add the conversion here
      *
+     * <p>Expressions whose top-level {@link FunctionDefinition} is not in the supported {@link
+     * #FILTERS} map (e.g. {@code COALESCE}, {@code CASE}, {@code IF}, {@code CAST}) return {@link
+     * Optional#empty()}. The caller ({@code BigQueryDynamicTableSource.applyFilters}) treats an
+     * empty result as "rejected by BigQuery" and leaves the predicate as a remaining Flink Calc
+     * filter, which is also why a sub-expression of {@code NOT} that is unsupported must short-
+     * circuit to empty rather than throw: the {@code NOT} case recurses through {@code convert}
+     * and any unmapped child function would otherwise crash job planning.
+     *
      * @param flinkExpression the Flink expression
      * @return An {@link Optional} potentially containing the resolved row restriction for BigQuery.
      */
@@ -115,6 +121,15 @@ public class BigQueryRestriction {
 
         CallExpression call = (CallExpression) flinkExpression;
         Operation op = FILTERS.get(call.getFunctionDefinition());
+        if (op == null) {
+            // Function definition is not in the supported FILTERS map. Returning empty lets
+            // applyFilters route this predicate to the remaining-filters list (applied by a
+            // Flink Calc node after the source) instead of unboxing a null Operation in the
+            // switch below and throwing NullPointerException during job planning. Without
+            // this guard, any unsupported scalar function in a pushable position (most
+            // commonly NOT wrapping an unmapped child like COALESCE) crashes the planner.
+            return Optional.empty();
+        }
         switch (op) {
             case IS_NULL:
                 return onlyChildColumnPath(call).map(field -> field + " IS NULL");
@@ -155,10 +170,10 @@ public class BigQueryRestriction {
                 return convertLike(call);
 
             default:
-                throw new BigQueryConnectorException(
-                        String.format(
-                                "The provided Flink expression is not supported %s.",
-                                call.getFunctionName()));
+                // Defensive: a value present in FILTERS but missing from this switch would land
+                // here. Treat it the same as an unsupported function — let the planner keep the
+                // predicate as a Flink Calc filter instead of failing the whole job.
+                return Optional.empty();
         }
     }
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/restrictions/BigQueryRestrictionTest.java
@@ -289,6 +289,85 @@ public class BigQueryRestrictionTest {
         assertThat(result).hasValue("city IS NULL");
     }
 
+    // ------------------------------------------------------------------------
+    // Functions that are not in BigQueryRestriction.FILTERS (e.g. COALESCE,
+    // CASE, IF, CAST) must not throw NullPointerException. They must return
+    // Optional.empty() so applyFilters routes the predicate to the remaining-
+    // filters list (applied by a Flink Calc node after the source) instead of
+    // crashing job planning.
+    //
+    // The original regression was reported from the catalog-foundry
+    // `catalog_feed` pipeline with the predicate
+    //   NOT COALESCE(opted_out_of_secondary_channels_catalog, FALSE)
+    // where NOT recurses into convert() and the unmapped COALESCE child
+    // previously caused a NullPointerException during job planning.
+    // ------------------------------------------------------------------------
+
+    @Test
+    public void testUnsupportedTopLevelFunctionReturnsEmpty() {
+        FieldReferenceExpression field = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "coalesce",
+                                BuiltInFunctionDefinitions.COALESCE,
+                                DataTypes.BOOLEAN(),
+                                field,
+                                fallback));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testNotOfUnsupportedFunctionReturnsEmpty() {
+        FieldReferenceExpression field = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+        CallExpression coalesceCall =
+                createCallExpression(
+                        "coalesce",
+                        BuiltInFunctionDefinitions.COALESCE,
+                        DataTypes.BOOLEAN(),
+                        field,
+                        fallback);
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createCallExpression(
+                                "not",
+                                BuiltInFunctionDefinitions.NOT,
+                                DataTypes.BOOLEAN(),
+                                coalesceCall));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testAndOfSupportedAndUnsupportedReturnsEmpty() {
+        FieldReferenceExpression city = createField("city", DataTypes.STRING());
+        ValueLiteralExpression toronto = createLiteral("Toronto", DataTypes.STRING().notNull());
+        FieldReferenceExpression flag = createField("flag", DataTypes.BOOLEAN());
+        ValueLiteralExpression fallback = createLiteral(false, DataTypes.BOOLEAN().notNull());
+
+        CallExpression supportedSide = createEqualsCallExpression(city, toronto);
+        CallExpression unsupportedSide =
+                createCallExpression(
+                        "coalesce",
+                        BuiltInFunctionDefinitions.COALESCE,
+                        DataTypes.BOOLEAN(),
+                        flag,
+                        fallback);
+
+        Optional<String> result =
+                BigQueryRestriction.convert(
+                        createAndCallExpression(supportedSide, unsupportedSide));
+
+        // The whole AND collapses to empty (mixed pushability is not partially expressible as a
+        // single row restriction); applyFilters then leaves the AND as a remaining Flink filter.
+        assertThat(result).isEmpty();
+    }
+
     private FieldReferenceExpression createField(String name, DataType type) {
         return new FieldReferenceExpression(name, type, 0, 0);
     }


### PR DESCRIPTION
## Problem

`BigQueryRestriction.convert` looks up the call's `FunctionDefinition` in the `FILTERS` map and then does `switch (op)` without a null check. Any function definition not in the map (e.g. `COALESCE`, `CASE`, `IF`, `CAST`) unboxes a null `Operation` and throws `NullPointerException` during job planning.

The `NOT` branch recurses through `convert`, so a predicate like:

```sql
NOT COALESCE(opted_out_of_secondary_channels_catalog, FALSE)
```

triggers the NPE through the recursion even though `NOT` itself is supported. This is the shape that surfaced the regression in Shopify's catalog-foundry `catalog_feed` pipeline.

## Root cause

PR #324 ("Changed applyFilters so only filters rejected by BQ are left as remaining") changed the contract: `convert` must now express "rejected" via `Optional.empty()` rather than throwing. The `FILTERS.get(...)` null case was never updated to match.

## Fix

- Add a null check immediately after `FILTERS.get(...)`. If `op == null`, return `Optional.empty()` so `applyFilters` routes the predicate to the remaining-filters list (applied by a Flink Calc node after the source).
- Collapse the `default:` branch of the switch from a thrown `BigQueryConnectorException` to the same `Optional.empty()` behaviour, so a value present in `FILTERS` but missing from the switch — a future maintenance hazard — doesn't crash the planner either.
- Remove the now-unused `BigQueryConnectorException` import.

## Tests

Three new tests in `BigQueryRestrictionTest`:

| Test | Scenario | Previously | Now |
|---|---|---|---|
| `testUnsupportedTopLevelFunctionReturnsEmpty` | `COALESCE(...)` at top level | `NullPointerException` | `Optional.empty()` |
| `testNotOfUnsupportedFunctionReturnsEmpty` | `NOT COALESCE(...)` — the catalog-foundry crash shape | `NullPointerException` | `Optional.empty()` |
| `testAndOfSupportedAndUnsupportedReturnsEmpty` | `city = 'Toronto' AND COALESCE(flag, FALSE)` | `NullPointerException` | `Optional.empty()` |

Co-authored-by: Josie Kupke <josie.kupke@shopify.com>