### PR TITLE
Add optional BigQuery source startup gate

### DIFF
--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
@@ -49,6 +49,8 @@ public class BigQuerySourceEnumerator
     private final SplitEnumeratorContext<BigQuerySourceSplit> context;
     private final BigQuerySourceSplitAssigner splitAssigner;
     private final TreeSet<Integer> readersAwaitingSplit;
+    private final boolean waitForAllSourceReaders;
+    private boolean started;
 
     public BigQuerySourceEnumerator(
             Boundedness boundedness,
@@ -59,6 +61,8 @@ public class BigQuerySourceEnumerator
         this.context = context;
         this.splitAssigner = createBigQuerySourceSplitAssigner(readOptions, sourceEnumState);
         this.readersAwaitingSplit = new TreeSet<>();
+        this.waitForAllSourceReaders = readOptions.getWaitForAllSourceReaders();
+        this.started = sourceEnumState.isInitialized();
     }
 
     final BigQuerySourceSplitAssigner createBigQuerySourceSplitAssigner(
@@ -80,7 +84,7 @@ public class BigQuerySourceEnumerator
 
     @Override
     public void start() {
-        splitAssigner.openAndDiscoverSplits();
+        maybeStart();
     }
 
     @Override
@@ -91,7 +95,9 @@ public class BigQuerySourceEnumerator
         }
 
         readersAwaitingSplit.add(subtaskId);
-        assignSplits();
+        if (maybeStart()) {
+            assignSplits();
+        }
     }
 
     @Override
@@ -107,6 +113,9 @@ public class BigQuerySourceEnumerator
     @Override
     public void addReader(int subtaskId) {
         LOG.debug("Adding reader {} to BigQuerySourceEnumerator.", subtaskId);
+        if (maybeStart()) {
+            assignSplits();
+        }
     }
 
     @Override
@@ -163,6 +172,36 @@ public class BigQuerySourceEnumerator
 
     @Override
     public void notifySplits() {
-        assignSplits();
+        if (maybeStart()) {
+            assignSplits();
+        }
+    }
+
+    private boolean maybeStart() {
+        if (started) {
+            return true;
+        }
+
+        int registeredReaders = context.registeredReaders().size();
+        int expectedReaders = context.currentParallelism();
+        if (waitForAllSourceReaders && registeredReaders < expectedReaders) {
+            LOG.debug(
+                    "Waiting to start BigQuery Source Enumerator until all source readers are "
+                            + "registered ({}/{}).",
+                    registeredReaders,
+                    expectedReaders);
+            return false;
+        }
+
+        if (waitForAllSourceReaders) {
+            LOG.info(
+                    "Starting BigQuery Source Enumerator after all source readers are registered "
+                            + "({}/{}).",
+                    registeredReaders,
+                    expectedReaders);
+        }
+        splitAssigner.openAndDiscoverSplits();
+        started = true;
+        return true;
     }
 }

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -68,6 +68,7 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.ROW_RESTRICTION);
         additionalOptions.add(BigQueryConnectorOptions.COLUMNS_PROJECTION);
         additionalOptions.add(BigQueryConnectorOptions.MAX_STREAM_COUNT);
+        additionalOptions.add(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS);
         additionalOptions.add(BigQueryConnectorOptions.SNAPSHOT_TIMESTAMP);
         additionalOptions.add(BigQueryConnectorOptions.CREDENTIALS_ACCESS_TOKEN);
         additionalOptions.add(BigQueryConnectorOptions.CREDENTIALS_FILE);
@@ -97,6 +98,7 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.ROW_RESTRICTION);
         forwardOptions.add(BigQueryConnectorOptions.COLUMNS_PROJECTION);
         forwardOptions.add(BigQueryConnectorOptions.MAX_STREAM_COUNT);
+        forwardOptions.add(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS);
         forwardOptions.add(BigQueryConnectorOptions.SNAPSHOT_TIMESTAMP);
         forwardOptions.add(BigQueryConnectorOptions.CREDENTIALS_ACCESS_TOKEN);
         forwardOptions.add(BigQueryConnectorOptions.CREDENTIALS_FILE);

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -115,6 +115,19 @@ public class BigQueryConnectorOptions {
                                     + " BigQuery can decide for less than this number.");
 
     /**
+     * [OPTIONAL, Read Configuration] Boolean value indicating whether read session creation should
+     * wait until all expected source readers have registered.<br>
+     * Default: false - Create the read session when the source enumerator starts.
+     */
+    public static final ConfigOption<Boolean> WAIT_FOR_ALL_SOURCE_READERS =
+            ConfigOptions.key("read.wait-for-all-source-readers")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether the BigQuery read session should wait until all expected "
+                                    + "source readers have registered.");
+
+    /**
      * Read Configuration: Long value indicating the millis since epoch for the underlying table
      * snapshot. Connector would read records from this snapshot instance table. <br>
      * Default: latest snapshot is read.

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -106,6 +106,8 @@ public class BigQueryTableConfigurationProvider {
                         Optional.ofNullable(config.get(BigQueryConnectorOptions.COLUMNS_PROJECTION))
                                 .map(cols -> Arrays.asList(cols.split(",")))
                                 .orElse(new ArrayList<>()))
+                .setWaitForAllSourceReaders(
+                        config.get(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS))
                 .setBigQueryConnectOptions(translateBigQueryConnectOptions())
                 .setLimit(config.get(BigQueryConnectorOptions.LIMIT))
                 .build();

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
@@ -40,12 +40,104 @@ public class BigQuerySourceEnumeratorTest {
 
     @Before
     public void beforeTest() throws IOException {
+        StorageClientFaker.FakeBigQueryServices.STORAGE_READ_CLIENT_INVOCATIONS.set(0);
         this.readOptions =
                 StorageClientFaker.createReadOptions(
                                 0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING)
                         .toBuilder()
                         .setParallelism(1)
                         .build();
+    }
+
+    @Test
+    public void startOpensReadSessionWithoutWaitingByDefault() throws Exception {
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED,
+                            ctx,
+                            readOptions,
+                            BigQuerySourceEnumState.initialState());
+
+            enumerator.start();
+
+            assertThat(storageReadClientInvocations()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void startWaitsForAllReadersBeforeOpeningReadSession() throws Exception {
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED,
+                            ctx,
+                            readOptionsWaitingForAllReaders(),
+                            BigQuerySourceEnumState.initialState());
+
+            enumerator.start();
+            assertThat(storageReadClientInvocations()).isEqualTo(0);
+
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            enumerator.addReader(0);
+            assertThat(storageReadClientInvocations()).isEqualTo(0);
+
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+            enumerator.addReader(1);
+            assertThat(storageReadClientInvocations()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void splitRequestsBeforeStartupAreAssignedAfterAllReadersRegister() throws Exception {
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED,
+                            ctx,
+                            readOptionsWaitingForAllReaders(),
+                            BigQuerySourceEnumState.initialState());
+
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            enumerator.addReader(0);
+            enumerator.handleSplitRequest(0, host(0));
+
+            assertThat(ctx.getSplitsAssignmentSequence()).isEmpty();
+
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+            enumerator.addReader(1);
+
+            assertThat(ctx.getSplitsAssignmentSequence()).hasSize(1);
+            SplitsAssignment<BigQuerySourceSplit> assignment =
+                    ctx.getSplitsAssignmentSequence().get(0);
+            assertThat(assignment.assignment()).containsKey(0);
+        }
+    }
+
+    @Test
+    public void restoredStateDoesNotWaitForAllReadersBeforeAssigningSplits() throws Exception {
+        BigQuerySourceEnumState seed = seedWithOneRemainingStream();
+
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED, ctx, readOptionsWaitingForAllReaders(), seed);
+
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            enumerator.addReader(0);
+            enumerator.handleSplitRequest(0, host(0));
+
+            assertThat(ctx.getSplitsAssignmentSequence()).hasSize(1);
+            SplitsAssignment<BigQuerySourceSplit> assignment =
+                    ctx.getSplitsAssignmentSequence().get(0);
+            assertThat(assignment.assignment()).containsKey(0);
+        }
     }
 
     @Test
@@ -113,6 +205,14 @@ public class BigQuerySourceEnumeratorTest {
 
     private static String host(int subtaskId) {
         return "host-" + subtaskId;
+    }
+
+    private static int storageReadClientInvocations() {
+        return StorageClientFaker.FakeBigQueryServices.STORAGE_READ_CLIENT_INVOCATIONS.get();
+    }
+
+    private BigQueryReadOptions readOptionsWaitingForAllReaders() {
+        return readOptions.toBuilder().setWaitForAllSourceReaders(true).build();
     }
 
     private BigQuerySourceEnumState seedWithOneRemainingStream() {

--- a/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-1.17-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -88,6 +88,7 @@ public class BigQueryDynamicTableFactoryTest {
         Map<String, String> properties = getRequiredOptions();
         properties.put(BigQueryConnectorOptions.COLUMNS_PROJECTION.key(), "aaa,bbb");
         properties.put(BigQueryConnectorOptions.MAX_STREAM_COUNT.key(), "100");
+        properties.put(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS.key(), "true");
         properties.put(
                 BigQueryConnectorOptions.ROW_RESTRICTION.key(), "aaa > 10 AND NOT bbb IS NULL");
         properties.put(
@@ -103,6 +104,7 @@ public class BigQueryDynamicTableFactoryTest {
                         .setMaxStreamCount(100)
                         .setRowRestriction("aaa > 10 AND NOT bbb IS NULL")
                         .setSnapshotTimestampInMillis(Instant.EPOCH.toEpochMilli())
+                        .setWaitForAllSourceReaders(true)
                         .setBigQueryConnectOptions(connectorOptions.getBigQueryConnectOptions())
                         .build();
 

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumerator.java
@@ -49,6 +49,8 @@ public class BigQuerySourceEnumerator
     private final SplitEnumeratorContext<BigQuerySourceSplit> context;
     private final BigQuerySourceSplitAssigner splitAssigner;
     private final TreeSet<Integer> readersAwaitingSplit;
+    private final boolean waitForAllSourceReaders;
+    private boolean started;
 
     public BigQuerySourceEnumerator(
             Boundedness boundedness,
@@ -59,6 +61,8 @@ public class BigQuerySourceEnumerator
         this.context = context;
         this.splitAssigner = createBigQuerySourceSplitAssigner(readOptions, sourceEnumState);
         this.readersAwaitingSplit = new TreeSet<>();
+        this.waitForAllSourceReaders = readOptions.getWaitForAllSourceReaders();
+        this.started = sourceEnumState.isInitialized();
     }
 
     final BigQuerySourceSplitAssigner createBigQuerySourceSplitAssigner(
@@ -80,7 +84,7 @@ public class BigQuerySourceEnumerator
 
     @Override
     public void start() {
-        splitAssigner.openAndDiscoverSplits();
+        maybeStart();
     }
 
     @Override
@@ -91,7 +95,9 @@ public class BigQuerySourceEnumerator
         }
 
         readersAwaitingSplit.add(subtaskId);
-        assignSplits();
+        if (maybeStart()) {
+            assignSplits();
+        }
     }
 
     @Override
@@ -107,6 +113,9 @@ public class BigQuerySourceEnumerator
     @Override
     public void addReader(int subtaskId) {
         LOG.debug("Adding reader {} to BigQuerySourceEnumerator.", subtaskId);
+        if (maybeStart()) {
+            assignSplits();
+        }
     }
 
     @Override
@@ -163,6 +172,36 @@ public class BigQuerySourceEnumerator
 
     @Override
     public void notifySplits() {
-        assignSplits();
+        if (maybeStart()) {
+            assignSplits();
+        }
+    }
+
+    private boolean maybeStart() {
+        if (started) {
+            return true;
+        }
+
+        int registeredReaders = context.registeredReaders().size();
+        int expectedReaders = context.currentParallelism();
+        if (waitForAllSourceReaders && registeredReaders < expectedReaders) {
+            LOG.debug(
+                    "Waiting to start BigQuery Source Enumerator until all source readers are "
+                            + "registered ({}/{}).",
+                    registeredReaders,
+                    expectedReaders);
+            return false;
+        }
+
+        if (waitForAllSourceReaders) {
+            LOG.info(
+                    "Starting BigQuery Source Enumerator after all source readers are registered "
+                            + "({}/{}).",
+                    registeredReaders,
+                    expectedReaders);
+        }
+        splitAssigner.openAndDiscoverSplits();
+        started = true;
+        return true;
     }
 }

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactory.java
@@ -68,6 +68,7 @@ public class BigQueryDynamicTableFactory
         additionalOptions.add(BigQueryConnectorOptions.ROW_RESTRICTION);
         additionalOptions.add(BigQueryConnectorOptions.COLUMNS_PROJECTION);
         additionalOptions.add(BigQueryConnectorOptions.MAX_STREAM_COUNT);
+        additionalOptions.add(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS);
         additionalOptions.add(BigQueryConnectorOptions.SNAPSHOT_TIMESTAMP);
         additionalOptions.add(BigQueryConnectorOptions.CREDENTIALS_ACCESS_TOKEN);
         additionalOptions.add(BigQueryConnectorOptions.CREDENTIALS_FILE);
@@ -107,6 +108,7 @@ public class BigQueryDynamicTableFactory
         forwardOptions.add(BigQueryConnectorOptions.ROW_RESTRICTION);
         forwardOptions.add(BigQueryConnectorOptions.COLUMNS_PROJECTION);
         forwardOptions.add(BigQueryConnectorOptions.MAX_STREAM_COUNT);
+        forwardOptions.add(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS);
         forwardOptions.add(BigQueryConnectorOptions.SNAPSHOT_TIMESTAMP);
         forwardOptions.add(BigQueryConnectorOptions.CREDENTIALS_ACCESS_TOKEN);
         forwardOptions.add(BigQueryConnectorOptions.CREDENTIALS_FILE);

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryConnectorOptions.java
@@ -116,6 +116,19 @@ public class BigQueryConnectorOptions {
                                     + " BigQuery can decide for less than this number.");
 
     /**
+     * [OPTIONAL, Read Configuration] Boolean value indicating whether read session creation should
+     * wait until all expected source readers have registered.<br>
+     * Default: false - Create the read session when the source enumerator starts.
+     */
+    public static final ConfigOption<Boolean> WAIT_FOR_ALL_SOURCE_READERS =
+            ConfigOptions.key("read.wait-for-all-source-readers")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether the BigQuery read session should wait until all expected "
+                                    + "source readers have registered.");
+
+    /**
      * Read Configuration: Long value indicating the millis since epoch for the underlying table
      * snapshot. Connector would read records from this snapshot instance table. <br>
      * Default: latest snapshot is read.

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/main/java/com/google/cloud/flink/bigquery/table/config/BigQueryTableConfigurationProvider.java
@@ -157,6 +157,8 @@ public class BigQueryTableConfigurationProvider {
                         Optional.ofNullable(config.get(BigQueryConnectorOptions.COLUMNS_PROJECTION))
                                 .map(cols -> Arrays.asList(cols.split(",")))
                                 .orElse(new ArrayList<>()))
+                .setWaitForAllSourceReaders(
+                        config.get(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS))
                 .setBigQueryConnectOptions(translateBigQueryConnectOptions())
                 .setLimit(config.get(BigQueryConnectorOptions.LIMIT))
                 .build();

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/source/enumerator/BigQuerySourceEnumeratorTest.java
@@ -40,12 +40,104 @@ public class BigQuerySourceEnumeratorTest {
 
     @Before
     public void beforeTest() throws IOException {
+        StorageClientFaker.FakeBigQueryServices.STORAGE_READ_CLIENT_INVOCATIONS.set(0);
         this.readOptions =
                 StorageClientFaker.createReadOptions(
                                 0, 2, StorageClientFaker.SIMPLE_AVRO_SCHEMA_STRING)
                         .toBuilder()
                         .setParallelism(1)
                         .build();
+    }
+
+    @Test
+    public void startOpensReadSessionWithoutWaitingByDefault() throws Exception {
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED,
+                            ctx,
+                            readOptions,
+                            BigQuerySourceEnumState.initialState());
+
+            enumerator.start();
+
+            assertThat(storageReadClientInvocations()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void startWaitsForAllReadersBeforeOpeningReadSession() throws Exception {
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED,
+                            ctx,
+                            readOptionsWaitingForAllReaders(),
+                            BigQuerySourceEnumState.initialState());
+
+            enumerator.start();
+            assertThat(storageReadClientInvocations()).isEqualTo(0);
+
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            enumerator.addReader(0);
+            assertThat(storageReadClientInvocations()).isEqualTo(0);
+
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+            enumerator.addReader(1);
+            assertThat(storageReadClientInvocations()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void splitRequestsBeforeStartupAreAssignedAfterAllReadersRegister() throws Exception {
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED,
+                            ctx,
+                            readOptionsWaitingForAllReaders(),
+                            BigQuerySourceEnumState.initialState());
+
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            enumerator.addReader(0);
+            enumerator.handleSplitRequest(0, host(0));
+
+            assertThat(ctx.getSplitsAssignmentSequence()).isEmpty();
+
+            ctx.registerReader(new ReaderInfo(1, host(1)));
+            enumerator.addReader(1);
+
+            assertThat(ctx.getSplitsAssignmentSequence()).hasSize(1);
+            SplitsAssignment<BigQuerySourceSplit> assignment =
+                    ctx.getSplitsAssignmentSequence().get(0);
+            assertThat(assignment.assignment()).containsKey(0);
+        }
+    }
+
+    @Test
+    public void restoredStateDoesNotWaitForAllReadersBeforeAssigningSplits() throws Exception {
+        BigQuerySourceEnumState seed = seedWithOneRemainingStream();
+
+        try (MockSplitEnumeratorContext<BigQuerySourceSplit> ctx =
+                new MockSplitEnumeratorContext<>(2)) {
+            BigQuerySourceEnumerator enumerator =
+                    new BigQuerySourceEnumerator(
+                            Boundedness.BOUNDED, ctx, readOptionsWaitingForAllReaders(), seed);
+
+            enumerator.start();
+            ctx.registerReader(new ReaderInfo(0, host(0)));
+            enumerator.addReader(0);
+            enumerator.handleSplitRequest(0, host(0));
+
+            assertThat(ctx.getSplitsAssignmentSequence()).hasSize(1);
+            SplitsAssignment<BigQuerySourceSplit> assignment =
+                    ctx.getSplitsAssignmentSequence().get(0);
+            assertThat(assignment.assignment()).containsKey(0);
+        }
     }
 
     @Test
@@ -113,6 +205,14 @@ public class BigQuerySourceEnumeratorTest {
 
     private static String host(int subtaskId) {
         return "host-" + subtaskId;
+    }
+
+    private static int storageReadClientInvocations() {
+        return StorageClientFaker.FakeBigQueryServices.STORAGE_READ_CLIENT_INVOCATIONS.get();
+    }
+
+    private BigQueryReadOptions readOptionsWaitingForAllReaders() {
+        return readOptions.toBuilder().setWaitForAllSourceReaders(true).build();
     }
 
     private BigQuerySourceEnumState seedWithOneRemainingStream() {

--- a/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
+++ b/flink-2.1-connector-bigquery/flink-connector-bigquery/src/test/java/com/google/cloud/flink/bigquery/table/BigQueryDynamicTableFactoryTest.java
@@ -95,6 +95,7 @@ public class BigQueryDynamicTableFactoryTest {
         Map<String, String> properties = getRequiredOptions();
         properties.put(BigQueryConnectorOptions.COLUMNS_PROJECTION.key(), "aaa,bbb");
         properties.put(BigQueryConnectorOptions.MAX_STREAM_COUNT.key(), "100");
+        properties.put(BigQueryConnectorOptions.WAIT_FOR_ALL_SOURCE_READERS.key(), "true");
         properties.put(
                 BigQueryConnectorOptions.ROW_RESTRICTION.key(), "aaa > 10 AND NOT bbb IS NULL");
         properties.put(
@@ -110,6 +111,7 @@ public class BigQueryDynamicTableFactoryTest {
                         .setMaxStreamCount(100)
                         .setRowRestriction("aaa > 10 AND NOT bbb IS NULL")
                         .setSnapshotTimestampInMillis(Instant.EPOCH.toEpochMilli())
+                        .setWaitForAllSourceReaders(true)
                         .setBigQueryConnectOptions(connectorOptions.getBigQueryConnectOptions())
                         .build();
 

--- a/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/source/config/BigQueryReadOptions.java
+++ b/flink-connector-bigquery-common/src/main/java/com/google/cloud/flink/bigquery/source/config/BigQueryReadOptions.java
@@ -55,6 +55,8 @@ public abstract class BigQueryReadOptions implements Serializable {
 
     public abstract Integer getParallelism();
 
+    public abstract Boolean getWaitForAllSourceReaders();
+
     public abstract BigQueryConnectOptions getBigQueryConnectOptions();
 
     public int getEffectiveMaxStreamCount() {
@@ -89,6 +91,7 @@ public abstract class BigQueryReadOptions implements Serializable {
                 getSnapshotTimestampInMillis(),
                 getMaxStreamCount(),
                 getParallelism(),
+                getWaitForAllSourceReaders(),
                 getBigQueryConnectOptions());
     }
 
@@ -110,6 +113,8 @@ public abstract class BigQueryReadOptions implements Serializable {
                         this.getSnapshotTimestampInMillis(), other.getSnapshotTimestampInMillis())
                 && Objects.equals(this.getMaxStreamCount(), other.getMaxStreamCount())
                 && Objects.equals(this.getParallelism(), other.getParallelism())
+                && Objects.equals(
+                        this.getWaitForAllSourceReaders(), other.getWaitForAllSourceReaders())
                 && Objects.equals(
                         this.getBigQueryConnectOptions(), other.getBigQueryConnectOptions());
     }
@@ -133,6 +138,7 @@ public abstract class BigQueryReadOptions implements Serializable {
                 .setMaxStreamCount(0)
                 .setMaxRecordsPerSplitFetch(10000)
                 .setParallelism(0)
+                .setWaitForAllSourceReaders(false)
                 .setSnapshotTimestampInMillis(null);
     }
 
@@ -201,6 +207,15 @@ public abstract class BigQueryReadOptions implements Serializable {
          * @return This {@link Builder} instance.
          */
         public abstract Builder setParallelism(Integer parallelism);
+
+        /**
+         * Sets whether the source enumerator should wait for all source readers to register before
+         * opening the BigQuery read session.
+         *
+         * @param waitForAllSourceReaders Whether to wait for all source readers before startup.
+         * @return This {@link Builder} instance.
+         */
+        public abstract Builder setWaitForAllSourceReaders(Boolean waitForAllSourceReaders);
 
         /**
          * Sets the {@link BigQueryConnectOptions} instance.


### PR DESCRIPTION
## Summary
- Add `read.wait-for-all-source-readers` so bounded BigQuery sources can opt into delaying read session creation until all source readers have registered.
- Keep eager read session creation as the default behavior.
- Preserve checkpoint recovery behavior by treating initialized enumerator state as already started.
- Apply the same option, enumerator behavior, and coverage to the Flink 1.17 and Flink 2.1 connector variants.

## Testing
- mvn -Pflink_1.17 -pl flink-1.17-connector-bigquery/flink-connector-bigquery -am -Dtest=BigQuerySourceEnumeratorTest,BigQueryDynamicTableFactoryTest -DfailIfNoTests=false test
- mvn -Pflink_2.1 -pl flink-2.1-connector-bigquery/flink-connector-bigquery -am -Dtest=BigQuerySourceEnumeratorTest,BigQueryDynamicTableFactoryTest -DfailIfNoTests=false test